### PR TITLE
fix(dashboard): harden modal interactions and rendering

### DIFF
--- a/app/[locale]/dashboard-client.tsx
+++ b/app/[locale]/dashboard-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import dynamic from "next/dynamic";
+import { useState, useEffect, useCallback, useRef, useMemo, type ComponentType } from "react";
 import { useTranslations } from "next-intl";
 import { SectionNav } from "@/components/dashboard/section-nav";
 import { ScrollToTop } from "@/components/ui/scroll-to-top";
@@ -22,23 +23,6 @@ import { RailwayTolls } from "@/components/dashboard/railway-tolls";
 import { OECDComparison } from "@/components/dashboard/oecd-comparison";
 import { TimelinePanel } from "@/components/dashboard/timeline-panel";
 import { DetailModal } from "@/components/ui/detail-modal";
-import { IncomeTaxDetail } from "@/components/detail/income-tax-detail";
-import { CorporateTaxDetail } from "@/components/detail/corporate-tax-detail";
-import { FlatTaxDetail } from "@/components/detail/flat-tax-detail";
-import { VatDetail } from "@/components/detail/vat-detail";
-import { SalaryContributionsDetail } from "@/components/detail/salary-contributions-detail";
-import { FuelTaxDetail } from "@/components/detail/fuel-tax-detail";
-import { BehavioralTaxDetail } from "@/components/detail/behavioral-tax-detail";
-import { WelfareSystemDetail } from "@/components/detail/welfare-system-detail";
-import { IndicatorsDetail } from "@/components/detail/indicators-detail";
-import { PropertyTaxDetail } from "@/components/detail/property-tax-detail";
-import { RentalTaxDetail } from "@/components/detail/rental-tax-detail";
-import { InheritanceTaxDetail } from "@/components/detail/inheritance-tax-detail";
-import { CapitalGainsDetail } from "@/components/detail/capital-gains-detail";
-import { HighwayTollsDetail } from "@/components/detail/highway-tolls-detail";
-import { RailwayTollsDetail } from "@/components/detail/railway-tolls-detail";
-import { ComparisonDetail } from "@/components/detail/comparison-detail";
-import { DonateDetail } from "@/components/detail/donate-detail";
 import { DonateCta } from "@/components/dashboard/donate-cta";
 import { DonateHook } from "@/components/dashboard/donate-hook";
 import {
@@ -67,65 +51,133 @@ type ModalSlug =
   | "comparison"
   | "donate";
 
-const MODAL_CONTENT: Record<ModalSlug, React.ComponentType> = {
-  "income-tax": IncomeTaxDetail,
-  "corporate-tax": CorporateTaxDetail,
-  "flat-tax": FlatTaxDetail,
-  "vat": VatDetail,
-  "salary-contributions": SalaryContributionsDetail,
-  "fuel-tax": FuelTaxDetail,
-  "behavioral-tax": BehavioralTaxDetail,
-  "welfare-system": WelfareSystemDetail,
-  "indicators": IndicatorsDetail,
-  "property-tax": PropertyTaxDetail,
-  "rental-tax": RentalTaxDetail,
-  "inheritance-tax": InheritanceTaxDetail,
-  "capital-gains": CapitalGainsDetail,
-  "highway-tolls": HighwayTollsDetail,
-  "railway-tolls": RailwayTollsDetail,
-  "comparison": ComparisonDetail,
-  "donate": DonateDetail,
+function ModalFallback() {
+  return (
+    <div
+      className="my-8 h-64 animate-pulse rounded border border-gray-800 bg-background/50"
+      aria-hidden="true"
+    />
+  );
+}
+
+const MODAL_CONTENT: Record<ModalSlug, ComponentType> = {
+  "income-tax": dynamic(
+    () => import("@/components/detail/income-tax-detail").then((m) => m.IncomeTaxDetail),
+    { loading: ModalFallback },
+  ),
+  "corporate-tax": dynamic(
+    () => import("@/components/detail/corporate-tax-detail").then((m) => m.CorporateTaxDetail),
+    { loading: ModalFallback },
+  ),
+  "flat-tax": dynamic(
+    () => import("@/components/detail/flat-tax-detail").then((m) => m.FlatTaxDetail),
+    { loading: ModalFallback },
+  ),
+  "vat": dynamic(
+    () => import("@/components/detail/vat-detail").then((m) => m.VatDetail),
+    { loading: ModalFallback },
+  ),
+  "salary-contributions": dynamic(
+    () => import("@/components/detail/salary-contributions-detail").then((m) => m.SalaryContributionsDetail),
+    { loading: ModalFallback },
+  ),
+  "fuel-tax": dynamic(
+    () => import("@/components/detail/fuel-tax-detail").then((m) => m.FuelTaxDetail),
+    { loading: ModalFallback },
+  ),
+  "behavioral-tax": dynamic(
+    () => import("@/components/detail/behavioral-tax-detail").then((m) => m.BehavioralTaxDetail),
+    { loading: ModalFallback },
+  ),
+  "welfare-system": dynamic(
+    () => import("@/components/detail/welfare-system-detail").then((m) => m.WelfareSystemDetail),
+    { loading: ModalFallback },
+  ),
+  "indicators": dynamic(
+    () => import("@/components/detail/indicators-detail").then((m) => m.IndicatorsDetail),
+    { loading: ModalFallback },
+  ),
+  "property-tax": dynamic(
+    () => import("@/components/detail/property-tax-detail").then((m) => m.PropertyTaxDetail),
+    { loading: ModalFallback },
+  ),
+  "rental-tax": dynamic(
+    () => import("@/components/detail/rental-tax-detail").then((m) => m.RentalTaxDetail),
+    { loading: ModalFallback },
+  ),
+  "inheritance-tax": dynamic(
+    () => import("@/components/detail/inheritance-tax-detail").then((m) => m.InheritanceTaxDetail),
+    { loading: ModalFallback },
+  ),
+  "capital-gains": dynamic(
+    () => import("@/components/detail/capital-gains-detail").then((m) => m.CapitalGainsDetail),
+    { loading: ModalFallback },
+  ),
+  "highway-tolls": dynamic(
+    () => import("@/components/detail/highway-tolls-detail").then((m) => m.HighwayTollsDetail),
+    { loading: ModalFallback },
+  ),
+  "railway-tolls": dynamic(
+    () => import("@/components/detail/railway-tolls-detail").then((m) => m.RailwayTollsDetail),
+    { loading: ModalFallback },
+  ),
+  "comparison": dynamic(
+    () => import("@/components/detail/comparison-detail").then((m) => m.ComparisonDetail),
+    { loading: ModalFallback },
+  ),
+  "donate": dynamic(
+    () => import("@/components/detail/donate-detail").then((m) => m.DonateDetail),
+    { loading: ModalFallback },
+  ),
 };
 
 const HASH_MODAL_MAP: Record<string, ModalSlug> = { donate: "donate" };
-
-let hashInitialized = false;
 
 export function DashboardClient() {
   const [openModal, setOpenModal] = useState<ModalSlug | null>(null);
   const scrollFired = useRef(new Set<number>());
   const timeFired = useRef(new Set<number>());
+  const lastHashModalRef = useRef<string | null>(null);
 
-  const open = (slug: ModalSlug) => () => {
+  const open = useCallback((slug: ModalSlug) => () => {
     trackPanelClick(slug);
     if (slug === "donate") trackDonateOpen("panel");
     setOpenModal(slug);
-  };
+  }, []);
 
-  const close = () => {
+  const close = useCallback(() => {
     setOpenModal(null);
     if (window.location.hash) {
-      history.replaceState(null, "", window.location.pathname);
+      const url = new URL(window.location.href);
+      url.hash = "";
+      window.history.replaceState(null, "", `${url.pathname}${url.search}`);
     }
-  };
+    lastHashModalRef.current = null;
+  }, []);
 
   const checkHash = useCallback(() => {
     const hash = window.location.hash.slice(1);
     const slug = HASH_MODAL_MAP[hash];
-    if (slug) {
-      if (slug === "donate") trackDonateOpen("hash");
-      setOpenModal(slug);
+    if (!slug) {
+      if (lastHashModalRef.current) {
+        lastHashModalRef.current = null;
+        setOpenModal(null);
+      }
+      return;
     }
+
+    if (lastHashModalRef.current !== hash) {
+      if (slug === "donate") trackDonateOpen("hash");
+      lastHashModalRef.current = hash;
+    }
+    setOpenModal(slug);
   }, []);
 
-  // Initialize from hash on page load (only on first render)
+  // Initialize from hash on every mount so navigation back to /#donate opens reliably.
   useEffect(() => {
-    if (!hashInitialized) {
-      hashInitialized = true;
-      checkHash();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    const frame = requestAnimationFrame(checkHash);
+    return () => cancelAnimationFrame(frame);
+  }, [checkHash]);
 
   // Listen to hash changes
   useEffect(() => {
@@ -168,14 +220,17 @@ export function DashboardClient() {
 
   const t = useTranslations("sectionNav");
 
-  const sections = [
-    { id: "direct-taxes", label: t("directTaxes") },
-    { id: "indirect-taxes", label: t("indirectTaxes") },
-    { id: "income-welfare", label: t("incomeWelfare") },
-    { id: "real-estate", label: t("realEstate") },
-    { id: "wealth-transfer", label: t("wealthTransfer") },
-    { id: "infrastructure", label: t("infrastructure") },
-  ];
+  const sections = useMemo(
+    () => [
+      { id: "direct-taxes", label: t("directTaxes") },
+      { id: "indirect-taxes", label: t("indirectTaxes") },
+      { id: "income-welfare", label: t("incomeWelfare") },
+      { id: "real-estate", label: t("realEstate") },
+      { id: "wealth-transfer", label: t("wealthTransfer") },
+      { id: "infrastructure", label: t("infrastructure") },
+    ],
+    [t],
+  );
 
   return (
     <>

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -38,11 +38,11 @@ export default async function HomePage({ params }: PageProps) {
       <main id="main-content" className="flex-1">
         <h1 className="sr-only">{t("title")}</h1>
         <ThreatLevel />
-        <SectionObserver section="tax-map" className="relative z-0 mx-auto max-w-7xl px-4 pt-6">
-          <TaxMapClient />
-        </SectionObserver>
         <SectionObserver section="journey-of-100">
           <JourneyOf100 />
+        </SectionObserver>
+        <SectionObserver section="tax-map" className="relative z-0 mx-auto max-w-7xl px-4 pt-6">
+          <TaxMapClient />
         </SectionObserver>
         <SectionObserver section="dashboard-panels">
           <DashboardClient />

--- a/components/dashboard/behavioral-tax.tsx
+++ b/components/dashboard/behavioral-tax.tsx
@@ -29,7 +29,7 @@ export function BehavioralTax({ onOpenDetail }: BehavioralTaxProps) {
       aria-label={t("title")}
       className="group block cursor-pointer"
       onClick={onOpenDetail}
-      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") onOpenDetail?.(); }}
+      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onOpenDetail?.(); } }}
     >
       <div className="h-full rounded border-2 border-blanc bg-panel p-5 transition-colors group-hover:border-blanc">
         <h2 className="flex items-center gap-2 font-display text-base font-bold uppercase tracking-widest text-blanc">

--- a/components/dashboard/capital-gains.tsx
+++ b/components/dashboard/capital-gains.tsx
@@ -23,7 +23,7 @@ export function CapitalGains({ onOpenDetail }: CapitalGainsProps) {
       aria-label={t("title")}
       className="group block cursor-pointer"
       onClick={onOpenDetail}
-      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") onOpenDetail?.(); }}
+      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onOpenDetail?.(); } }}
     >
       <div className="h-full rounded border-2 border-blanc bg-panel p-5 transition-colors group-hover:border-blanc">
         <h2 className="flex items-center gap-2 font-display text-base font-bold uppercase tracking-widest text-blanc">

--- a/components/dashboard/corporate-tax.tsx
+++ b/components/dashboard/corporate-tax.tsx
@@ -19,7 +19,7 @@ export function CorporateTax({ onOpenDetail }: CorporateTaxProps) {
       aria-label={t("title")}
       className="group block cursor-pointer"
       onClick={onOpenDetail}
-      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") onOpenDetail?.(); }}
+      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onOpenDetail?.(); } }}
     >
       <div className="h-full rounded border-2 border-blanc bg-panel p-5 transition-colors group-hover:border-blanc">
         <h2 className="flex items-center gap-2 font-display text-base font-bold uppercase tracking-widest text-blanc">

--- a/components/dashboard/flat-tax.tsx
+++ b/components/dashboard/flat-tax.tsx
@@ -18,7 +18,7 @@ export function FlatTax({ onOpenDetail }: FlatTaxProps) {
       aria-label={t("title")}
       className="group block cursor-pointer"
       onClick={onOpenDetail}
-      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") onOpenDetail?.(); }}
+      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onOpenDetail?.(); } }}
     >
       <div className="h-full rounded border-2 border-blanc bg-panel p-5 transition-colors group-hover:border-blanc">
         <h2 className="flex items-center gap-2 font-display text-base font-bold uppercase tracking-widest text-blanc">

--- a/components/dashboard/fuel-tax.tsx
+++ b/components/dashboard/fuel-tax.tsx
@@ -26,7 +26,7 @@ export function FuelTax({ onOpenDetail }: FuelTaxProps) {
       aria-label={t("title")}
       className="group block cursor-pointer"
       onClick={onOpenDetail}
-      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") onOpenDetail?.(); }}
+      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onOpenDetail?.(); } }}
     >
       <div className="h-full rounded border-2 border-blanc bg-panel p-5 transition-colors group-hover:border-blanc">
         <h2 className="flex items-center gap-2 font-display text-base font-bold uppercase tracking-widest text-blanc">

--- a/components/dashboard/highway-tolls.tsx
+++ b/components/dashboard/highway-tolls.tsx
@@ -18,7 +18,7 @@ export function HighwayTolls({ onOpenDetail }: HighwayTollsProps) {
       aria-label={t("title")}
       className="group block cursor-pointer"
       onClick={onOpenDetail}
-      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") onOpenDetail?.(); }}
+      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onOpenDetail?.(); } }}
     >
       <div className="h-full rounded border-2 border-blanc bg-panel p-5 transition-colors group-hover:border-blanc">
         <h2 className="flex items-center gap-2 font-display text-base font-bold uppercase tracking-widest text-blanc">

--- a/components/dashboard/inheritance-tax.tsx
+++ b/components/dashboard/inheritance-tax.tsx
@@ -18,7 +18,7 @@ export function InheritanceTax({ onOpenDetail }: InheritanceTaxProps) {
       aria-label={t("title")}
       className="group block cursor-pointer"
       onClick={onOpenDetail}
-      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") onOpenDetail?.(); }}
+      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onOpenDetail?.(); } }}
     >
       <div className="h-full rounded border-2 border-blanc bg-panel p-5 transition-colors group-hover:border-blanc">
         <h2 className="flex items-center gap-2 font-display text-base font-bold uppercase tracking-widest text-blanc">

--- a/components/dashboard/macro-indicators.tsx
+++ b/components/dashboard/macro-indicators.tsx
@@ -45,7 +45,7 @@ export function MacroIndicators({ onOpenDetail }: MacroIndicatorsProps) {
       aria-label={t("title")}
       className="group block cursor-pointer"
       onClick={onOpenDetail}
-      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") onOpenDetail?.(); }}
+      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onOpenDetail?.(); } }}
     >
       <div className="h-full rounded border-2 border-blanc bg-panel p-5 transition-colors group-hover:border-blanc">
         <h2 className="flex items-center gap-2 font-display text-base font-bold uppercase tracking-widest text-blanc">

--- a/components/dashboard/oecd-comparison.tsx
+++ b/components/dashboard/oecd-comparison.tsx
@@ -22,7 +22,7 @@ export function OECDComparison({ onOpenDetail }: OECDComparisonProps) {
       aria-label={t("title")}
       className="group flex flex-col cursor-pointer h-full"
       onClick={onOpenDetail}
-      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") onOpenDetail?.(); }}
+      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onOpenDetail?.(); } }}
     >
       <div className="flex flex-col flex-1 rounded border-2 border-blanc bg-panel p-5 transition-colors group-hover:border-blanc">
         <h2 className="flex items-center gap-2 font-display text-base font-bold uppercase tracking-widest text-blanc">

--- a/components/dashboard/property-tax.tsx
+++ b/components/dashboard/property-tax.tsx
@@ -24,7 +24,7 @@ export function PropertyTax({ onOpenDetail }: PropertyTaxProps) {
       aria-label={t("title")}
       className="group block cursor-pointer"
       onClick={onOpenDetail}
-      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") onOpenDetail?.(); }}
+      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onOpenDetail?.(); } }}
     >
       <div className="h-full rounded border-2 border-blanc bg-panel p-5 transition-colors group-hover:border-blanc">
         <h2 className="flex items-center gap-2 font-display text-base font-bold uppercase tracking-widest text-blanc">

--- a/components/dashboard/railway-tolls.tsx
+++ b/components/dashboard/railway-tolls.tsx
@@ -18,7 +18,7 @@ export function RailwayTolls({ onOpenDetail }: RailwayTollsProps) {
       aria-label={t("title")}
       className="group block cursor-pointer"
       onClick={onOpenDetail}
-      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") onOpenDetail?.(); }}
+      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onOpenDetail?.(); } }}
     >
       <div className="h-full rounded border-2 border-blanc bg-panel p-5 transition-colors group-hover:border-blanc">
         <h2 className="flex items-center gap-2 font-display text-base font-bold uppercase tracking-widest text-blanc">

--- a/components/dashboard/rental-tax.tsx
+++ b/components/dashboard/rental-tax.tsx
@@ -18,7 +18,7 @@ export function RentalTax({ onOpenDetail }: RentalTaxProps) {
       aria-label={t("title")}
       className="group block cursor-pointer"
       onClick={onOpenDetail}
-      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") onOpenDetail?.(); }}
+      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onOpenDetail?.(); } }}
     >
       <div className="h-full rounded border-2 border-blanc bg-panel p-5 transition-colors group-hover:border-blanc">
         <h2 className="flex items-center gap-2 font-display text-base font-bold uppercase tracking-widest text-blanc">

--- a/components/dashboard/salary-cost.tsx
+++ b/components/dashboard/salary-cost.tsx
@@ -23,7 +23,7 @@ export function SalaryCost({ onOpenDetail }: SalaryCostProps) {
       aria-label={t("title")}
       className="group block cursor-pointer"
       onClick={onOpenDetail}
-      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") onOpenDetail?.(); }}
+      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onOpenDetail?.(); } }}
     >
       <div className="rounded border-2 border-blanc bg-panel p-5 transition-colors group-hover:border-blanc">
         <h2 className="flex items-center gap-2 font-display text-base font-bold uppercase tracking-widest text-blanc">

--- a/components/dashboard/shared/share-button.tsx
+++ b/components/dashboard/shared/share-button.tsx
@@ -1,7 +1,7 @@
-'use client';
+"use client";
 
-import { useTranslations } from 'next-intl';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
 
 export interface ShareButtonProps {
   title: string;
@@ -16,22 +16,38 @@ export function ShareButton({
   url,
   onShare,
 }: ShareButtonProps) {
-  const t = useTranslations('interactiveCalculators.shareButton');
+  const t = useTranslations("interactiveCalculators.shareButton");
   const [feedback, setFeedback] = useState<string | null>(null);
+  const [canNativeShare, setCanNativeShare] = useState(false);
+  const feedbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => {
+      setCanNativeShare(typeof navigator !== "undefined" && "share" in navigator);
+    });
+    return () => {
+      cancelAnimationFrame(frame);
+      if (feedbackTimerRef.current) {
+        clearTimeout(feedbackTimerRef.current);
+      }
+    };
+  }, []);
 
   const handleCopyToClipboard = async () => {
     try {
       const shareUrl = url || window.location.href;
-      const text = `${title}${description ? ` — ${description}` : ''}\n\n${shareUrl}`;
+      const text = `${title}${description ? `, ${description}` : ""}\n\n${shareUrl}`;
 
       await navigator.clipboard.writeText(text);
-      setFeedback(t('copyToClipboard'));
+      setFeedback(t("copyToClipboard"));
       onShare?.();
 
-      // Clear feedback after 2 seconds
-      setTimeout(() => setFeedback(null), 2000);
+      if (feedbackTimerRef.current) {
+        clearTimeout(feedbackTimerRef.current);
+      }
+      feedbackTimerRef.current = setTimeout(() => setFeedback(null), 2000);
     } catch (error) {
-      console.error('Failed to copy to clipboard:', error);
+      console.error("Failed to copy to clipboard:", error);
     }
   };
 
@@ -46,8 +62,7 @@ export function ShareButton({
       });
       onShare?.();
     } catch (error) {
-      // User cancelled share or error occurred
-      console.error('Share failed:', error);
+      console.error("Share failed:", error);
     }
   };
 
@@ -58,21 +73,21 @@ export function ShareButton({
       <button
         onClick={handleCopyToClipboard}
         className="px-3 py-2 text-sm font-semibold bg-blue-600 hover:bg-blue-500 active:bg-blue-700 text-white rounded transition-colors"
-        title={t('label')}
-        aria-label={t('label')}
+        title={t("label")}
+        aria-label={t("label")}
       >
-        {feedback || t('label')}
+        {feedback || t("label")}
       </button>
 
       {/* Native share button (mobile) */}
-      {'share' in navigator && (
+      {canNativeShare && (
         <button
           onClick={handleNativeShare}
           className="px-3 py-2 text-sm font-semibold bg-blue-700 hover:bg-blue-600 active:bg-blue-800 text-white rounded transition-colors"
-          title={t('label')}
-          aria-label={t('label')}
+          title={t("label")}
+          aria-label={t("label")}
         >
-          {t('label')}
+          {t("label")}
         </button>
       )}
 
@@ -80,10 +95,10 @@ export function ShareButton({
       {/* <button
         onClick={handleGenerateImage}
         className="px-3 py-2 text-sm font-semibold bg-amber-600 hover:bg-amber-500 active:bg-amber-700 text-white rounded transition-colors"
-        title={t('shareOgImage')}
-        aria-label={t('shareOgImage')}
+        title={t("shareOgImage")}
+        aria-label={t("shareOgImage")}
       >
-        {t('shareOgImage')}
+        {t("shareOgImage")}
       </button> */}
     </div>
   );

--- a/components/dashboard/tax-brackets.tsx
+++ b/components/dashboard/tax-brackets.tsx
@@ -36,7 +36,7 @@ export function TaxBrackets({ onOpenDetail }: TaxBracketsProps) {
       aria-label={t("title")}
       className="group flex flex-col cursor-pointer h-full"
       onClick={onOpenDetail}
-      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") onOpenDetail?.(); }}
+      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onOpenDetail?.(); } }}
     >
       <div className="flex flex-col flex-1 rounded border-2 border-blanc bg-panel p-5 transition-colors group-hover:border-blanc">
         <h2 className="flex items-center gap-2 font-display text-base font-bold uppercase tracking-widest text-blanc">

--- a/components/dashboard/tax-map-client.tsx
+++ b/components/dashboard/tax-map-client.tsx
@@ -68,6 +68,7 @@ function Legend({ legendOpen, onToggle, activeCategories, onToggleCategory, lege
                 <button
                   key={cat}
                   onClick={() => onToggleCategory(cat)}
+                  aria-pressed={active}
                   className={`flex w-full items-center gap-2 rounded px-1 py-0.5 text-[11px] transition-opacity ${active ? "opacity-100" : "opacity-40"} hover:opacity-90`}
                   style={{ fontFamily: "Inter, sans-serif" }}
                 >
@@ -139,12 +140,15 @@ export function TaxMapClient() {
 
   useEffect(() => {
     if (!fullscreen) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") closeFullscreen(); };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") closeFullscreen();
+    };
+    const previousOverflow = document.body.style.overflow;
     document.addEventListener("keydown", onKey);
     document.body.style.overflow = "hidden";
     return () => {
       document.removeEventListener("keydown", onKey);
-      document.body.style.overflow = "";
+      document.body.style.overflow = previousOverflow;
     };
   }, [fullscreen, closeFullscreen]);
 
@@ -159,7 +163,7 @@ export function TaxMapClient() {
 
   return (
     <>
-      {/* ── Preview panel ── */}
+      {/* Preview panel */}
       <div className="rounded border-2 border-blanc bg-panel overflow-hidden">
         <div className="flex items-start justify-between gap-4 px-5 pt-4 pb-3">
           <div>
@@ -177,7 +181,7 @@ export function TaxMapClient() {
           </div>
         </div>
 
-        {/* Map hidden (not unmounted) when fullscreen is open — avoids z-index bleed */}
+        {/* Map hidden when fullscreen is open, avoids z-index bleed without remounting. */}
         <div className={`relative ${fullscreen ? "invisible" : ""}`}>
           <TaxMapLeaflet
             height="clamp(400px, 50vw, 580px)"
@@ -207,7 +211,7 @@ export function TaxMapClient() {
         </div>
       </div>
 
-      {/* ── Fullscreen modal ── */}
+      {/* Fullscreen modal */}
       {fullscreen && (
         <div
           className="fixed inset-0 z-[9999] flex flex-col bg-background"
@@ -232,7 +236,7 @@ export function TaxMapClient() {
               </div>
               <button
                 onClick={closeFullscreen}
-                aria-label="Fermer"
+                aria-label={t("closeLabel")}
                 className="flex h-8 w-8 items-center justify-center rounded-full border border-[#1e2a3a] text-muted transition-colors hover:border-blanc/30 hover:text-blanc"
               >
                 <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth={2}>

--- a/components/dashboard/tax-map.tsx
+++ b/components/dashboard/tax-map.tsx
@@ -3,6 +3,7 @@
 import "leaflet/dist/leaflet.css";
 import { useEffect, useRef, useCallback, type MutableRefObject } from "react";
 import { useLocale } from "next-intl";
+import type { Map as LeafletMap, Marker } from "leaflet";
 import type { TaxMapCategory } from "@/lib/tax-map-data";
 import { TAX_MAP_DATA } from "@/lib/tax-map-data";
 import { umamiTrack } from "@/lib/analytics";
@@ -85,7 +86,7 @@ const MAP_STYLES = `
   }
 `;
 
-// Global flag — styles are shared across all instances
+// Global flag, styles are shared across all instances.
 let mapStylesInjected = false;
 
 interface TaxMapLeafletProps {
@@ -98,15 +99,14 @@ interface TaxMapLeafletProps {
 export function TaxMapLeaflet({ height, interactive = true, activeCategories, resetViewRef }: TaxMapLeafletProps) {
   const locale = useLocale();
   const mapRef = useRef<HTMLDivElement>(null);
-  const mapInstanceRef = useRef<unknown>(null);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const markersRef = useRef<Map<string, any>>(new Map());
+  const mapInstanceRef = useRef<LeafletMap | null>(null);
+  const markersRef = useRef<Map<string, Marker>>(new Map());
 
-  // Stable ref for activeCategories so initMap reads current value at add-time
+  // Stable ref for activeCategories so initMap reads the current value at add-time.
   const activeCategoriesRef = useRef(activeCategories);
   useEffect(() => {
     activeCategoriesRef.current = activeCategories;
-  });
+  }, [activeCategories]);
 
   const buildPopup = useCallback((point: (typeof TAX_MAP_DATA)[0]) => {
     const color = CATEGORY_COLORS[point.category];
@@ -145,9 +145,13 @@ export function TaxMapLeaflet({ height, interactive = true, activeCategories, re
 
   useEffect(() => {
     if (!mapRef.current || mapInstanceRef.current) return;
+    let cancelled = false;
+    let frameId: number | null = null;
+    const markers = markersRef.current;
 
     const initMap = async () => {
       const L = (await import("leaflet")).default;
+      if (cancelled || !mapRef.current || mapInstanceRef.current) return;
 
       if (!mapStylesInjected) {
         mapStylesInjected = true;
@@ -155,8 +159,6 @@ export function TaxMapLeaflet({ height, interactive = true, activeCategories, re
         styleEl.textContent = MAP_STYLES;
         document.head.appendChild(styleEl);
       }
-
-      if (!mapRef.current) return;
 
       const map = L.map(mapRef.current, {
         center: DEFAULT_CENTER,
@@ -212,43 +214,44 @@ export function TaxMapLeaflet({ height, interactive = true, activeCategories, re
           });
         }
 
-        markersRef.current.set(point.id, marker);
+        markers.set(point.id, marker);
         if (currentCategories.has(point.category)) {
           marker.addTo(map);
         }
       });
     };
 
-    initMap().then(() => {
-      requestAnimationFrame(() => {
-        if (mapInstanceRef.current) {
-          (mapInstanceRef.current as { invalidateSize: () => void }).invalidateSize();
-        }
+    void initMap().then(() => {
+      if (cancelled) return;
+      frameId = requestAnimationFrame(() => {
+        mapInstanceRef.current?.invalidateSize();
       });
     });
 
     return () => {
-      if (mapInstanceRef.current) {
-        (mapInstanceRef.current as { remove: () => void }).remove();
-        mapInstanceRef.current = null;
-        markersRef.current.clear();
-        // Clear resetViewRef so stale instance is not called after unmount
-        if (resetViewRef) {
-          resetViewRef.current = null;
-        }
+      cancelled = true;
+      if (frameId !== null) {
+        cancelAnimationFrame(frameId);
+      }
+      const map = mapInstanceRef.current;
+      mapInstanceRef.current = null;
+      markers.clear();
+      map?.remove();
+      if (resetViewRef) {
+        resetViewRef.current = null;
       }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [buildPopup, interactive, resetViewRef]);
 
   // Update marker visibility when activeCategories changes
   useEffect(() => {
-    if (!mapInstanceRef.current) return;
+    const map = mapInstanceRef.current;
+    if (!map) return;
     TAX_MAP_DATA.forEach((point) => {
       const marker = markersRef.current.get(point.id);
       if (!marker) return;
       if (activeCategories.has(point.category)) {
-        marker.addTo(mapInstanceRef.current);
+        marker.addTo(map);
       } else {
         marker.remove();
       }

--- a/components/dashboard/timeline-gantt-modal.tsx
+++ b/components/dashboard/timeline-gantt-modal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useCallback, useEffect, useRef } from "react";
 import { useTranslations } from "next-intl";
 import { TIMELINE_EVENTS } from "@/lib/tax-data";
 
@@ -10,10 +11,33 @@ interface TimelineGanttModalProps {
 
 export function TimelineGanttModal({ isOpen, onClose }: TimelineGanttModalProps) {
   const t = useTranslations("timeline");
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    },
+    [onClose],
+  );
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    document.addEventListener("keydown", handleKeyDown);
+
+    const frame = requestAnimationFrame(() => contentRef.current?.focus());
+
+    return () => {
+      cancelAnimationFrame(frame);
+      document.body.style.overflow = previousOverflow;
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen, handleKeyDown]);
 
   if (!isOpen) return null;
 
-  // Calculate bar width percentage (years since 1914 / 112 years * 100)
   const calculateBarWidth = (year: number): number => {
     const yearsSince1914 = year - 1914;
     const totalYears = 2026 - 1914;
@@ -22,82 +46,94 @@ export function TimelineGanttModal({ isOpen, onClose }: TimelineGanttModalProps)
 
   return (
     <div
-      className="fixed inset-0 z-[1100] flex items-center justify-center bg-black/80 backdrop-blur-sm"
+      className="fixed inset-0 z-[1100] flex items-center justify-center bg-black/80 p-4 backdrop-blur-sm"
       onClick={onClose}
     >
-      <div className="relative w-full max-w-4xl rounded border-2 border-blanc bg-panel p-6 m-4" onClick={(e) => e.stopPropagation()}>
+      <div
+        ref={contentRef}
+        tabIndex={-1}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="timeline-gantt-title"
+        className="relative max-h-[calc(100dvh-2rem)] w-full max-w-5xl overflow-y-auto rounded border-2 border-blanc bg-panel p-4 outline-none sm:p-6"
+        onClick={(e) => e.stopPropagation()}
+      >
         {/* Header */}
         <div className="mb-6 flex items-start justify-between border-b border-blanc/20 pb-4">
           <div>
-            <h2 className="font-display text-lg font-bold uppercase tracking-widest text-blanc">
+            <h2 id="timeline-gantt-title" className="font-display text-lg font-bold uppercase tracking-widest text-blanc">
               {t("title")}
             </h2>
-            <p className="mt-1 font-mono text-xs text-blanc/70">
-              1914 &rarr; 2026 • Les jalons qui ont façonné l&apos;extraction
+            <p className="mt-1 font-mono text-xs text-muted">
+              {t("subtitle")}
             </p>
           </div>
           <button
             onClick={onClose}
-            className="text-xl text-blanc/70 hover:text-blanc transition-colors"
-            aria-label="Close modal"
+            className="flex h-9 w-9 shrink-0 items-center justify-center rounded border border-gray-800 text-muted transition-colors hover:border-blanc/30 hover:text-blanc"
+            aria-label={t("closeLabel")}
           >
-            ✕
+            <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth={2}>
+              <path d="M18 6 6 18M6 6l12 12" />
+            </svg>
           </button>
         </div>
 
         {/* Gantt Chart */}
-        <div className="mb-4">
-          {/* Timeline axis */}
-          <div className="mb-3 flex justify-between px-10 font-mono text-xs font-bold text-blanc/70">
-            <span>1900</span>
-            <span>1920</span>
-            <span>1940</span>
-            <span>1960</span>
-            <span>1980</span>
-            <span>2000</span>
-            <span>2020</span>
-          </div>
+        <div className="mb-4 overflow-x-auto">
+          <div className="min-w-[720px]">
+            {/* Timeline axis */}
+            <div className="mb-3 flex justify-between px-10 font-mono text-xs font-bold text-muted">
+              <span>1900</span>
+              <span>1920</span>
+              <span>1940</span>
+              <span>1960</span>
+              <span>1980</span>
+              <span>2000</span>
+              <span>2020</span>
+            </div>
 
-          {/* Gantt bars */}
-          <div className="space-y-2.5 px-10">
-            {TIMELINE_EVENTS.map((event) => (
-              <div key={event.key} className="flex items-center gap-3">
-                {/* Label */}
-                <div className="w-24 flex-shrink-0">
-                  <div
-                    className="font-mono text-xs font-bold"
-                    style={{ color: event.color }}
-                  >
-                    {event.year} {event.key.split(/(?=[A-Z])/).slice(0, -1).join("").toUpperCase()}
+            {/* Gantt bars */}
+            <div className="space-y-2.5 px-10">
+              {TIMELINE_EVENTS.map((event) => (
+                <div key={event.key} className="flex items-center gap-3">
+                  {/* Label */}
+                  <div className="w-28 flex-shrink-0">
+                    <div
+                      className="font-mono text-xs font-bold"
+                      style={{ color: event.color }}
+                    >
+                      {event.year}
+                    </div>
+                    <div className="mt-0.5 font-mono text-xs text-slate-300">
+                      {t(event.key as "ir1914")}
+                    </div>
                   </div>
-                  <div className="mt-0.5 font-mono text-xs text-blanc/70">
-                    {t(event.key as "ir1914")}
+
+                  {/* Bar */}
+                  <div className="flex-1 relative h-1.5 rounded bg-slate-900">
+                    <div
+                      className="h-full rounded transition-all"
+                      style={{
+                        width: `${calculateBarWidth(event.year)}%`,
+                        backgroundColor: event.color,
+                        boxShadow: `0 0 6px ${event.color}40`,
+                      }}
+                    />
+                  </div>
+
+                  {/* Value */}
+                  <div className="w-20 flex-shrink-0 text-right">
+                    <div
+                      className="font-mono text-xs font-bold"
+                      style={{ color: event.color }}
+                    >
+                      {event.displayValue}
+                    </div>
                   </div>
                 </div>
-
-                {/* Bar */}
-                <div className="flex-1 relative h-1.5 bg-slate-900 rounded">
-                  <div
-                    className="h-full rounded transition-all"
-                    style={{
-                      width: `${calculateBarWidth(event.year)}%`,
-                      backgroundColor: event.color,
-                      boxShadow: `0 0 6px ${event.color}40`,
-                    }}
-                  />
-                </div>
-
-                {/* Value */}
-                <div className="w-20 flex-shrink-0 text-right">
-                  <div
-                    className="font-mono text-xs font-bold"
-                    style={{ color: event.color }}
-                  >
-                    {event.displayValue}
-                  </div>
-                </div>
-              </div>
-            ))}
+              ))}
+            </div>
           </div>
         </div>
       </div>

--- a/components/dashboard/timeline-panel.tsx
+++ b/components/dashboard/timeline-panel.tsx
@@ -20,9 +20,18 @@ export function TimelinePanel() {
       <div
         className="rounded border-2 border-blanc bg-panel p-5 cursor-pointer hover:border-blanc/80 transition-colors"
         onClick={() => setIsModalOpen(true)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            setIsModalOpen(true);
+          }
+        }}
+        role="button"
+        tabIndex={0}
+        aria-label={t("openLabel")}
       >
         <h2 className="font-display text-base font-bold uppercase tracking-widest text-blanc mb-4">
-          CHRONOLOGIE FISCALE
+          {t("title")}
         </h2>
 
         {/* Mini Gantt preview */}

--- a/components/dashboard/tva.tsx
+++ b/components/dashboard/tva.tsx
@@ -27,7 +27,7 @@ export function TVA({ onOpenDetail }: TVAProps) {
       aria-label={t("title")}
       className="group block cursor-pointer"
       onClick={onOpenDetail}
-      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") onOpenDetail?.(); }}
+      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onOpenDetail?.(); } }}
     >
       <div className="h-full rounded border-2 border-blanc bg-panel p-5 transition-colors group-hover:border-blanc">
         <h2 className="flex items-center gap-2 font-display text-base font-bold uppercase tracking-widest text-blanc">

--- a/components/dashboard/welfare-system.tsx
+++ b/components/dashboard/welfare-system.tsx
@@ -19,7 +19,7 @@ export function WelfareSystem({ onOpenDetail }: WelfareSystemProps) {
       aria-label={t("title")}
       className="group block cursor-pointer"
       onClick={onOpenDetail}
-      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") onOpenDetail?.(); }}
+      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onOpenDetail?.(); } }}
     >
       <div className="h-full rounded border-2 border-blanc bg-panel p-5 transition-colors group-hover:border-blanc">
         <h2 className="flex items-center gap-2 font-display text-base font-bold uppercase tracking-widest text-blanc">

--- a/components/layout/donate-link.tsx
+++ b/components/layout/donate-link.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import type { MouseEvent, ReactNode } from "react";
+import { Link } from "@/lib/navigation";
+import { trackDonateOpen } from "@/lib/analytics";
+
+interface DonateLinkProps {
+  children: ReactNode;
+  className?: string;
+  source: "footer" | "header";
+}
+
+export function DonateLink({ children, className, source }: DonateLinkProps) {
+  function handleClick(event: MouseEvent<HTMLAnchorElement>) {
+    trackDonateOpen(source);
+
+    const path = window.location.pathname;
+    const isHome = path === "/" || path === "/en" || path === "/en/";
+    if (!isHome) return;
+
+    event.preventDefault();
+    if (window.location.hash !== "#donate") {
+      window.location.hash = "donate";
+    }
+    window.dispatchEvent(new Event("hashchange"));
+  }
+
+  return (
+    <Link href="/#donate" onClick={handleClick} className={className}>
+      {children}
+    </Link>
+  );
+}

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -1,14 +1,10 @@
-import Link from "next/link";
 import { getTranslations } from "next-intl/server";
-import { getLocale } from "next-intl/server";
 import { siteConfig } from "@/lib/config";
-import { localePath } from "@/lib/url";
-import type { Locale } from "@/lib/i18n/config";
 import { ReportButton } from "@/components/report/report-modal";
+import { DonateLink } from "@/components/layout/donate-link";
 
 export async function Footer() {
   const t = await getTranslations("footer");
-  const locale = await getLocale() as Locale;
   const year = new Date().getFullYear();
 
   return (
@@ -34,12 +30,12 @@ export async function Footer() {
 
           <ReportButton />
 
-          <Link
-            href={localePath("/", locale) + "#donate"}
+          <DonateLink
+            source="footer"
             className="font-mono text-favorable/60 transition-colors hover:text-favorable"
           >
             {t("donate")}
-          </Link>
+          </DonateLink>
 
           <span>{t("copyright", { year })}</span>
         </div>

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -5,8 +5,8 @@ import Image from "next/image";
 import { useTranslations } from "next-intl";
 import { Link } from "@/lib/navigation";
 import { LanguageSwitcher } from "@/components/layout/language-switcher";
+import { DonateLink } from "@/components/layout/donate-link";
 import { siteConfig } from "@/lib/config";
-import { trackDonateOpen } from "@/lib/analytics";
 
 export function Header() {
   const t = useTranslations("header");
@@ -97,17 +97,13 @@ export function Header() {
           </a>
 
           {/* Donate */}
-          <button
-            onClick={() => {
-              trackDonateOpen("header");
-              window.location.hash = "donate";
-              window.dispatchEvent(new HashChangeEvent("hashchange"));
-            }}
-            className="hidden items-center gap-1.5 rounded-full border border-gray-600 bg-white/5 px-3 py-1 text-xs font-semibold text-blanc transition-all hover:border-favorable/50 hover:bg-favorable/10 hover:text-favorable sm:flex cursor-pointer"
+          <DonateLink
+            source="header"
+            className="hidden items-center gap-1.5 rounded-full border border-gray-600 bg-white/5 px-3 py-1 text-xs font-semibold text-blanc transition-all hover:border-favorable/50 hover:bg-favorable/10 hover:text-favorable sm:flex"
           >
             <span className="text-sm leading-none" aria-hidden="true">$</span>
             {t("donate")}
-          </button>
+          </DonateLink>
 
           {/* Language toggle */}
           <LanguageSwitcher />

--- a/components/ui/detail-modal.tsx
+++ b/components/ui/detail-modal.tsx
@@ -20,15 +20,17 @@ export function DetailModal({ open, onClose, children }: DetailModalProps) {
   );
 
   useEffect(() => {
-    if (open) {
-      document.body.style.overflow = "hidden";
-      document.addEventListener("keydown", handleKeyDown);
-      contentRef.current?.focus();
-    } else {
-      document.body.style.overflow = "";
-    }
+    if (!open) return;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    document.addEventListener("keydown", handleKeyDown);
+
+    const frame = requestAnimationFrame(() => contentRef.current?.focus());
+
     return () => {
-      document.body.style.overflow = "";
+      cancelAnimationFrame(frame);
+      document.body.style.overflow = previousOverflow;
       document.removeEventListener("keydown", handleKeyDown);
     };
   }, [open, handleKeyDown]);
@@ -40,7 +42,7 @@ export function DetailModal({ open, onClose, children }: DetailModalProps) {
       ref={overlayRef}
       className="fixed inset-0 z-[1100] flex items-end justify-center sm:items-center"
     >
-      {/* Backdrop — clicking it closes the modal */}
+      {/* Backdrop, clicking it closes the modal */}
       <div
         className="absolute inset-0 bg-black/70 backdrop-blur-sm animate-modal-backdrop"
         onClick={onClose}

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -71,6 +71,7 @@ export function buildSeoMetadata({
   };
 
   return {
+    metadataBase: new URL(siteConfig.url),
     title,
     description,
     manifest: "/site.webmanifest",

--- a/messages/en.json
+++ b/messages/en.json
@@ -208,6 +208,9 @@
   },
   "timeline": {
     "title": "FISCAL TIMELINE",
+    "subtitle": "1914 → 2026 · Extraction milestones",
+    "openLabel": "Open the detailed fiscal timeline",
+    "closeLabel": "Close the fiscal timeline",
     "source": "Loi de finances & EU directives",
     "details": "DETAILS ▸",
     "ir1914": "Income tax",
@@ -1044,6 +1047,7 @@
     "cat_secondary-home": "Second Home",
     "cat_where-it-goes": "Where It Goes",
     "expandLabel": "Expand map",
+    "closeLabel": "Close map",
     "resetLabel": "Reset view"
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -208,6 +208,9 @@
   },
   "timeline": {
     "title": "CHRONOLOGIE FISCALE",
+    "subtitle": "1914 → 2026 · Jalons de l'extraction",
+    "openLabel": "Ouvrir la chronologie fiscale détaillée",
+    "closeLabel": "Fermer la chronologie fiscale",
     "source": "Loi de finances & directives EU",
     "details": "DÉTAILS ▸",
     "ir1914": "Impôt sur le revenu",
@@ -1044,6 +1047,7 @@
     "cat_secondary-home": "Résidence secondaire",
     "cat_where-it-goes": "Où va l'argent",
     "expandLabel": "Agrandir la carte",
+    "closeLabel": "Fermer la carte",
     "resetLabel": "Revenir à la vue initiale"
   }
 }


### PR DESCRIPTION
## Summary
- Fixes the donation modal flow from the homepage and detail pages, including hash handling and query preservation.
- Lazily loads dashboard detail modal content to reduce initial client work.
- Hardens timeline and map modal accessibility, Escape handling, scroll locking, and Leaflet cleanup.
- Moves the Journey of 100€ back above the tax map and adds metadataBase for social metadata.

## Validation
- npm run type-check
- npm run lint
- npm run build
- Browser checks on http://localhost:3000 for /#donate, /en/income-tax → donate, timeline modal, map fullscreen modal, and query preservation.