### PR TITLE
feat(seo): improve english search targeting

### DIFF
--- a/app/[locale]/behavioral-tax/page.tsx
+++ b/app/[locale]/behavioral-tax/page.tsx
@@ -36,6 +36,7 @@ export default async function BehavioralTaxPage({ params }: PageProps) {
         pageTitle={t("title")}
         pagePath="/behavioral-tax"
         homeLabel={td("backToDashboard")}
+        description={t("metaDescription")}
       />
       <div className="sticky top-0 z-50">
         <div className="flex h-1">

--- a/app/[locale]/capital-gains/page.tsx
+++ b/app/[locale]/capital-gains/page.tsx
@@ -36,6 +36,7 @@ export default async function CapitalGainsPage({ params }: PageProps) {
         pageTitle={t("title")}
         pagePath="/capital-gains"
         homeLabel={td("backToDashboard")}
+        description={t("metaDescription")}
       />
       <div className="sticky top-0 z-50">
         <div className="flex h-1">

--- a/app/[locale]/comparison/page.tsx
+++ b/app/[locale]/comparison/page.tsx
@@ -36,6 +36,7 @@ export default async function ComparisonPage({ params }: PageProps) {
         pageTitle={t("title")}
         pagePath="/comparison"
         homeLabel={td("backToDashboard")}
+        description={t("metaDescription")}
       />
       <div className="sticky top-0 z-50">
         <div className="flex h-1">

--- a/app/[locale]/corporate-tax/page.tsx
+++ b/app/[locale]/corporate-tax/page.tsx
@@ -36,6 +36,7 @@ export default async function CorporateTaxPage({ params }: PageProps) {
         pageTitle={t("title")}
         pagePath="/corporate-tax"
         homeLabel={td("backToDashboard")}
+        description={t("metaDescription")}
       />
       <div className="sticky top-0 z-50">
         <div className="flex h-1">

--- a/app/[locale]/donate/page.tsx
+++ b/app/[locale]/donate/page.tsx
@@ -36,6 +36,7 @@ export default async function DonatePage({ params }: PageProps) {
         pageTitle={t("title")}
         pagePath="/donate"
         homeLabel="impots.tax"
+        description={t("metaDescription")}
       />
 
       <div className="sticky top-0 z-50">

--- a/app/[locale]/flat-tax/page.tsx
+++ b/app/[locale]/flat-tax/page.tsx
@@ -44,6 +44,7 @@ export default async function FlatTaxPage({ params }: PageProps) {
         pageTitle={t("title")}
         pagePath="/flat-tax"
         homeLabel={td("backToDashboard")}
+        description={t("metaDescription")}
         faqs={faqs}
       />
       <div className="sticky top-0 z-50">

--- a/app/[locale]/fuel-tax/page.tsx
+++ b/app/[locale]/fuel-tax/page.tsx
@@ -36,6 +36,7 @@ export default async function FuelTaxPage({ params }: PageProps) {
         pageTitle={t("title")}
         pagePath="/fuel-tax"
         homeLabel={td("backToDashboard")}
+        description={t("metaDescription")}
       />
       <div className="sticky top-0 z-50">
         <div className="flex h-1">

--- a/app/[locale]/highway-tolls/page.tsx
+++ b/app/[locale]/highway-tolls/page.tsx
@@ -36,6 +36,7 @@ export default async function HighwayTollsPage({ params }: PageProps) {
         pageTitle={t("title")}
         pagePath="/highway-tolls"
         homeLabel={td("backToDashboard")}
+        description={t("metaDescription")}
       />
       <div className="sticky top-0 z-50">
         <div className="flex h-1">

--- a/app/[locale]/income-tax/page.tsx
+++ b/app/[locale]/income-tax/page.tsx
@@ -44,6 +44,7 @@ export default async function IncomeTaxPage({ params }: PageProps) {
         pageTitle={t("title")}
         pagePath="/income-tax"
         homeLabel={td("backToDashboard")}
+        description={t("metaDescription")}
         faqs={faqs}
       />
       <div className="sticky top-0 z-50">

--- a/app/[locale]/indicators/page.tsx
+++ b/app/[locale]/indicators/page.tsx
@@ -2,6 +2,7 @@ import { getTranslations } from "next-intl/server";
 import type { Locale } from "@/lib/i18n/config";
 import { buildSeoMetadata } from "@/lib/seo";
 import { StructuredData } from "@/components/detail/structured-data";
+import type { FaqItem } from "@/lib/seo";
 import { Breadcrumb } from "@/components/detail/breadcrumb";
 import { IndicatorsDetail } from "@/components/detail/indicators-detail";
 import { Header } from "@/components/layout/header";
@@ -28,6 +29,12 @@ export default async function IndicatorsPage({ params }: PageProps) {
   const t = await getTranslations({ locale, namespace: "detailIndicators" });
   const td = await getTranslations({ locale, namespace: "detail" });
   const typedLocale = locale as Locale;
+  const faqs: FaqItem[] = [
+    { question: t("faqQ1"), answer: t("faqA1") },
+    { question: t("faqQ2"), answer: t("faqA2") },
+    { question: t("faqQ3"), answer: t("faqA3") },
+    { question: t("faqQ4"), answer: t("faqA4") },
+  ];
 
   return (
     <div className="flex min-h-screen flex-col bg-background">
@@ -36,6 +43,8 @@ export default async function IndicatorsPage({ params }: PageProps) {
         pageTitle={t("title")}
         pagePath="/indicators"
         homeLabel={td("backToDashboard")}
+        description={t("metaDescription")}
+        faqs={faqs}
       />
       <div className="sticky top-0 z-50">
         <div className="flex h-1">

--- a/app/[locale]/inheritance-tax/page.tsx
+++ b/app/[locale]/inheritance-tax/page.tsx
@@ -44,6 +44,7 @@ export default async function InheritanceTaxPage({ params }: PageProps) {
         pageTitle={t("title")}
         pagePath="/inheritance-tax"
         homeLabel={td("backToDashboard")}
+        description={t("metaDescription")}
         faqs={faqs}
       />
       <div className="sticky top-0 z-50">

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import Script from "next/script";
 import { notFound } from "next/navigation";
-import { getTranslations } from "next-intl/server";
+import { getTranslations, setRequestLocale } from "next-intl/server";
 import { NextIntlClientProvider, hasLocale } from "next-intl";
 import { Inter } from "next/font/google";
 import { routing } from "@/lib/i18n/routing";
@@ -53,6 +53,7 @@ export default async function LocaleLayout({
   }
 
   const typedLocale = locale as Locale;
+  setRequestLocale(typedLocale);
 
   return (
     <html

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -7,6 +7,7 @@ import { Ticker } from "@/components/dashboard/ticker";
 import { Footer } from "@/components/layout/footer";
 import { DashboardClient } from "@/app/[locale]/dashboard-client";
 import { SectionObserver } from "@/components/analytics/section-observer";
+import { QuickAnswer } from "@/components/detail/quick-answer";
 
 interface PageProps {
   params: Promise<{ locale: string }>;
@@ -15,6 +16,7 @@ interface PageProps {
 export default async function HomePage({ params }: PageProps) {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "header" });
+  const seo = await getTranslations({ locale, namespace: "homeSeo" });
 
   return (
     <div className="flex min-h-screen flex-col">
@@ -38,6 +40,9 @@ export default async function HomePage({ params }: PageProps) {
       <main id="main-content" className="flex-1">
         <h1 className="sr-only">{t("title")}</h1>
         <ThreatLevel />
+        <div className="mx-auto max-w-7xl px-4 pt-6">
+          <QuickAnswer title={seo("quickAnswerTitle")} answer={seo("quickAnswer")} />
+        </div>
         <SectionObserver section="journey-of-100">
           <JourneyOf100 />
         </SectionObserver>

--- a/app/[locale]/property-tax/page.tsx
+++ b/app/[locale]/property-tax/page.tsx
@@ -44,6 +44,7 @@ export default async function PropertyTaxPage({ params }: PageProps) {
         pageTitle={t("title")}
         pagePath="/property-tax"
         homeLabel={td("backToDashboard")}
+        description={t("metaDescription")}
         faqs={faqs}
       />
       <div className="sticky top-0 z-50">

--- a/app/[locale]/railway-tolls/page.tsx
+++ b/app/[locale]/railway-tolls/page.tsx
@@ -36,6 +36,7 @@ export default async function RailwayTollsPage({ params }: PageProps) {
         pageTitle={t("title")}
         pagePath="/railway-tolls"
         homeLabel={td("backToDashboard")}
+        description={t("metaDescription")}
       />
       <div className="sticky top-0 z-50">
         <div className="flex h-1">

--- a/app/[locale]/rental-tax/page.tsx
+++ b/app/[locale]/rental-tax/page.tsx
@@ -36,6 +36,7 @@ export default async function RentalTaxPage({ params }: PageProps) {
         pageTitle={t("title")}
         pagePath="/rental-tax"
         homeLabel={td("backToDashboard")}
+        description={t("metaDescription")}
       />
       <div className="sticky top-0 z-50">
         <div className="flex h-1">

--- a/app/[locale]/salary-contributions/page.tsx
+++ b/app/[locale]/salary-contributions/page.tsx
@@ -45,6 +45,7 @@ export default async function SalaryContributionsPage({ params }: PageProps) {
         pageTitle={t("title")}
         pagePath="/salary-contributions"
         homeLabel={td("backToDashboard")}
+        description={t("metaDescription")}
         faqs={faqs}
       />
       <div className="sticky top-0 z-50">

--- a/app/[locale]/vat/page.tsx
+++ b/app/[locale]/vat/page.tsx
@@ -44,6 +44,7 @@ export default async function VatPage({ params }: PageProps) {
         pageTitle={t("title")}
         pagePath="/vat"
         homeLabel={td("backToDashboard")}
+        description={t("metaDescription")}
         faqs={faqs}
       />
       <div className="sticky top-0 z-50">

--- a/app/[locale]/welfare-system/page.tsx
+++ b/app/[locale]/welfare-system/page.tsx
@@ -2,6 +2,7 @@ import { getTranslations } from "next-intl/server";
 import type { Locale } from "@/lib/i18n/config";
 import { buildSeoMetadata } from "@/lib/seo";
 import { StructuredData } from "@/components/detail/structured-data";
+import type { FaqItem } from "@/lib/seo";
 import { Breadcrumb } from "@/components/detail/breadcrumb";
 import { WelfareSystemDetail } from "@/components/detail/welfare-system-detail";
 import { Header } from "@/components/layout/header";
@@ -28,6 +29,12 @@ export default async function WelfareSystemPage({ params }: PageProps) {
   const t = await getTranslations({ locale, namespace: "detailWelfareSystem" });
   const td = await getTranslations({ locale, namespace: "detail" });
   const typedLocale = locale as Locale;
+  const faqs: FaqItem[] = [
+    { question: t("faqQ1"), answer: t("faqA1") },
+    { question: t("faqQ2"), answer: t("faqA2") },
+    { question: t("faqQ3"), answer: t("faqA3") },
+    { question: t("faqQ4"), answer: t("faqA4") },
+  ];
 
   return (
     <div className="flex min-h-screen flex-col bg-background">
@@ -36,6 +43,8 @@ export default async function WelfareSystemPage({ params }: PageProps) {
         pageTitle={t("title")}
         pagePath="/welfare-system"
         homeLabel={td("backToDashboard")}
+        description={t("metaDescription")}
+        faqs={faqs}
       />
       <div className="sticky top-0 z-50">
         <div className="flex h-1">

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -3,7 +3,7 @@ import { siteConfig } from "@/lib/config";
 import { locales, defaultLocale } from "@/lib/i18n/config";
 
 // lastModified: update this date when content changes significantly
-const CONTENT_LAST_MODIFIED = new Date("2026-04-01");
+const CONTENT_LAST_MODIFIED = new Date("2026-05-04");
 
 const routes: Array<{ path: string; priority?: number; changeFrequency?: "weekly" | "monthly" }> = [
   { path: "", priority: 1, changeFrequency: "weekly" },

--- a/components/detail/flat-tax-detail.tsx
+++ b/components/detail/flat-tax-detail.tsx
@@ -3,6 +3,8 @@
 import { useTranslations } from "next-intl";
 import { FLAT_TAX_2025, FLAT_TAX_2026, TAX_DATA_YEAR } from "@/lib/tax-data";
 import { FaqSection } from "@/components/detail/faq-section";
+import { QuickAnswer } from "@/components/detail/quick-answer";
+import { RelatedReports, type RelatedReport } from "@/components/detail/related-reports";
 import type { FaqItem } from "@/lib/seo";
 
 export function FlatTaxDetail() {
@@ -14,6 +16,23 @@ export function FlatTaxDetail() {
     { question: t("faqQ2"), answer: t("faqA2") },
     { question: t("faqQ3"), answer: t("faqA3") },
     { question: t("faqQ4"), answer: t("faqA4") },
+  ];
+  const relatedReports: RelatedReport[] = [
+    {
+      href: "/capital-gains",
+      title: t("relatedCapitalGainsTitle"),
+      description: t("relatedCapitalGainsDesc"),
+    },
+    {
+      href: "/income-tax",
+      title: t("relatedIncomeTaxTitle"),
+      description: t("relatedIncomeTaxDesc"),
+    },
+    {
+      href: "/vat",
+      title: t("relatedVatTitle"),
+      description: t("relatedVatDesc"),
+    },
   ];
 
   return (
@@ -30,6 +49,8 @@ export function FlatTaxDetail() {
           {td("dataYear", { year: TAX_DATA_YEAR })}
         </p>
       </header>
+
+      <QuickAnswer title={t("quickAnswerTitle")} answer={t("quickAnswer")} />
 
       {/* Intro */}
       <section className="mb-10 rounded border border-gray-800 bg-[#0f1218] p-6">
@@ -139,6 +160,8 @@ export function FlatTaxDetail() {
       </section>
 
       <FaqSection title={t("faqTitle")} faqs={faqs} />
+
+      <RelatedReports title={td("relatedReports")} reports={relatedReports} />
 
       {/* Source */}
       <footer className="border-t border-gray-800 pt-4">

--- a/components/detail/income-tax-detail.tsx
+++ b/components/detail/income-tax-detail.tsx
@@ -3,6 +3,8 @@
 import { useTranslations } from "next-intl";
 import { IR_BRACKETS, TAX_DATA_YEAR } from "@/lib/tax-data";
 import { FaqSection } from "@/components/detail/faq-section";
+import { QuickAnswer } from "@/components/detail/quick-answer";
+import { RelatedReports, type RelatedReport } from "@/components/detail/related-reports";
 import type { FaqItem } from "@/lib/seo";
 
 const BRACKET_COLORS = [
@@ -39,6 +41,23 @@ export function IncomeTaxDetail() {
     { question: t("faqQ3"), answer: t("faqA3") },
     { question: t("faqQ4"), answer: t("faqA4") },
   ];
+  const relatedReports: RelatedReport[] = [
+    {
+      href: "/flat-tax",
+      title: t("relatedFlatTaxTitle"),
+      description: t("relatedFlatTaxDesc"),
+    },
+    {
+      href: "/salary-contributions",
+      title: t("relatedSalaryTitle"),
+      description: t("relatedSalaryDesc"),
+    },
+    {
+      href: "/comparison",
+      title: t("relatedComparisonTitle"),
+      description: t("relatedComparisonDesc"),
+    },
+  ];
 
   return (
     <>
@@ -54,6 +73,8 @@ export function IncomeTaxDetail() {
           {td("dataYear", { year: TAX_DATA_YEAR })}
         </p>
       </header>
+
+      <QuickAnswer title={t("quickAnswerTitle")} answer={t("quickAnswer")} />
 
       {/* Intro */}
       <section className="mb-10 rounded border border-gray-800 bg-[#0f1218] p-6">
@@ -143,6 +164,8 @@ export function IncomeTaxDetail() {
       </section>
 
       <FaqSection title={t("faqTitle")} faqs={faqs} />
+
+      <RelatedReports title={td("relatedReports")} reports={relatedReports} />
 
       {/* Source */}
       <footer className="border-t border-gray-800 pt-4">

--- a/components/detail/indicators-detail.tsx
+++ b/components/detail/indicators-detail.tsx
@@ -2,10 +2,37 @@
 
 import { useTranslations } from "next-intl";
 import { MACRO_INDICATORS, TAX_DATA_YEAR, USSR_COMPARISON } from "@/lib/tax-data";
+import { FaqSection } from "@/components/detail/faq-section";
+import { QuickAnswer } from "@/components/detail/quick-answer";
+import { RelatedReports, type RelatedReport } from "@/components/detail/related-reports";
+import type { FaqItem } from "@/lib/seo";
 
 export function IndicatorsDetail() {
   const t = useTranslations("detailIndicators");
   const td = useTranslations("detail");
+  const faqs: FaqItem[] = [
+    { question: t("faqQ1"), answer: t("faqA1") },
+    { question: t("faqQ2"), answer: t("faqA2") },
+    { question: t("faqQ3"), answer: t("faqA3") },
+    { question: t("faqQ4"), answer: t("faqA4") },
+  ];
+  const relatedReports: RelatedReport[] = [
+    {
+      href: "/comparison",
+      title: t("relatedComparisonTitle"),
+      description: t("relatedComparisonDesc"),
+    },
+    {
+      href: "/welfare-system",
+      title: t("relatedWelfareTitle"),
+      description: t("relatedWelfareDesc"),
+    },
+    {
+      href: "/salary-contributions",
+      title: t("relatedSalaryTitle"),
+      description: t("relatedSalaryDesc"),
+    },
+  ];
 
   return (
     <>
@@ -20,6 +47,8 @@ export function IndicatorsDetail() {
           {td("dataYear", { year: TAX_DATA_YEAR })}
         </p>
       </header>
+
+      <QuickAnswer title={t("quickAnswerTitle")} answer={t("quickAnswer")} />
 
       <section className="mb-10 rounded border border-gray-800 bg-[#0f1218] p-6">
         <p className="font-mono text-sm leading-relaxed text-blanc">
@@ -130,6 +159,10 @@ export function IndicatorsDetail() {
           {t("summaryDesc")}
         </p>
       </section>
+
+      <FaqSection title={t("faqTitle")} faqs={faqs} />
+
+      <RelatedReports title={td("relatedReports")} reports={relatedReports} />
 
       <footer className="border-t border-gray-800 pt-4">
         <p className="font-mono text-xs text-blanc">

--- a/components/detail/quick-answer.tsx
+++ b/components/detail/quick-answer.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+interface QuickAnswerProps {
+  title: string;
+  answer: string;
+}
+
+export function QuickAnswer({ title, answer }: QuickAnswerProps) {
+  return (
+    <section className="mb-10 rounded border border-info/30 bg-info/5 p-5">
+      <p className="font-mono text-xs font-bold uppercase tracking-wider text-info">
+        {title}
+      </p>
+      <p className="mt-3 font-mono text-sm leading-relaxed text-blanc">
+        {answer}
+      </p>
+    </section>
+  );
+}

--- a/components/detail/related-reports.tsx
+++ b/components/detail/related-reports.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { Link } from "@/lib/navigation";
+
+export interface RelatedReport {
+  href: string;
+  title: string;
+  description: string;
+}
+
+interface RelatedReportsProps {
+  title: string;
+  reports: RelatedReport[];
+}
+
+export function RelatedReports({ title, reports }: RelatedReportsProps) {
+  return (
+    <section className="mb-10">
+      <h2 className="mb-4 font-display text-xl font-bold uppercase tracking-wider text-blanc">
+        {title}
+      </h2>
+      <div className="grid gap-3 sm:grid-cols-3">
+        {reports.map((report) => (
+          <Link
+            key={report.href}
+            href={report.href}
+            className="rounded border border-gray-800 bg-panel p-4 transition-colors hover:border-info/40 hover:bg-info/5"
+          >
+            <h3 className="font-display text-sm font-bold uppercase tracking-wider text-blanc">
+              {report.title}
+            </h3>
+            <p className="mt-2 font-mono text-xs leading-relaxed text-slate-300">
+              {report.description}
+            </p>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/detail/structured-data.tsx
+++ b/components/detail/structured-data.tsx
@@ -1,4 +1,9 @@
-import { buildBreadcrumbJsonLd, buildFaqJsonLd, type FaqItem } from "@/lib/seo";
+import {
+  buildBreadcrumbJsonLd,
+  buildFaqJsonLd,
+  buildWebPageJsonLd,
+  type FaqItem,
+} from "@/lib/seo";
 import type { Locale } from "@/lib/i18n/config";
 
 interface StructuredDataProps {
@@ -6,6 +11,7 @@ interface StructuredDataProps {
   pageTitle: string;
   pagePath: string;
   homeLabel: string;
+  description?: string;
   faqs?: FaqItem[];
 }
 
@@ -14,6 +20,7 @@ export function StructuredData({
   pageTitle,
   pagePath,
   homeLabel,
+  description,
   faqs,
 }: StructuredDataProps) {
   const breadcrumb = buildBreadcrumbJsonLd(
@@ -23,9 +30,23 @@ export function StructuredData({
     ],
     locale,
   );
+  const webPage = description
+    ? buildWebPageJsonLd({
+        title: pageTitle,
+        description,
+        path: pagePath,
+        locale,
+      })
+    : null;
 
   return (
     <>
+      {webPage && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
+        />
+      )}
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}

--- a/components/detail/vat-detail.tsx
+++ b/components/detail/vat-detail.tsx
@@ -3,6 +3,8 @@
 import { useTranslations } from "next-intl";
 import { VAT_RATES, TAX_DATA_YEAR } from "@/lib/tax-data";
 import { FaqSection } from "@/components/detail/faq-section";
+import { QuickAnswer } from "@/components/detail/quick-answer";
+import { RelatedReports, type RelatedReport } from "@/components/detail/related-reports";
 import type { FaqItem } from "@/lib/seo";
 
 const RATE_KEYS = ["rateNormal", "rateIntermediate", "rateReduced", "rateSuperReduced"] as const;
@@ -25,6 +27,23 @@ export function VatDetail() {
     { question: t("faqQ3"), answer: t("faqA3") },
     { question: t("faqQ4"), answer: t("faqA4") },
   ];
+  const relatedReports: RelatedReport[] = [
+    {
+      href: "/fuel-tax",
+      title: t("relatedFuelTaxTitle"),
+      description: t("relatedFuelTaxDesc"),
+    },
+    {
+      href: "/behavioral-tax",
+      title: t("relatedBehavioralTaxTitle"),
+      description: t("relatedBehavioralTaxDesc"),
+    },
+    {
+      href: "/comparison",
+      title: t("relatedComparisonTitle"),
+      description: t("relatedComparisonDesc"),
+    },
+  ];
 
   return (
     <>
@@ -40,6 +59,8 @@ export function VatDetail() {
           {td("dataYear", { year: TAX_DATA_YEAR })}
         </p>
       </header>
+
+      <QuickAnswer title={t("quickAnswerTitle")} answer={t("quickAnswer")} />
 
       {/* Intro */}
       <section className="mb-10 rounded border border-gray-800 bg-[#0f1218] p-6">
@@ -95,6 +116,8 @@ export function VatDetail() {
       </section>
 
       <FaqSection title={t("faqTitle")} faqs={faqs} />
+
+      <RelatedReports title={td("relatedReports")} reports={relatedReports} />
 
       {/* Source */}
       <footer className="border-t border-gray-800 pt-4">

--- a/components/detail/welfare-system-detail.tsx
+++ b/components/detail/welfare-system-detail.tsx
@@ -2,6 +2,10 @@
 
 import { useTranslations } from "next-intl";
 import { WELFARE_DATA, TAX_DATA_YEAR } from "@/lib/tax-data";
+import { FaqSection } from "@/components/detail/faq-section";
+import { QuickAnswer } from "@/components/detail/quick-answer";
+import { RelatedReports, type RelatedReport } from "@/components/detail/related-reports";
+import type { FaqItem } from "@/lib/seo";
 
 const RSA_AMOUNTS = [
   { key: "rsaSingle", amount: "646.52 \u20ac" },
@@ -15,6 +19,29 @@ const RSA_AMOUNTS = [
 export function WelfareSystemDetail() {
   const t = useTranslations("detailWelfareSystem");
   const td = useTranslations("detail");
+  const faqs: FaqItem[] = [
+    { question: t("faqQ1"), answer: t("faqA1") },
+    { question: t("faqQ2"), answer: t("faqA2") },
+    { question: t("faqQ3"), answer: t("faqA3") },
+    { question: t("faqQ4"), answer: t("faqA4") },
+  ];
+  const relatedReports: RelatedReport[] = [
+    {
+      href: "/salary-contributions",
+      title: t("relatedSalaryTitle"),
+      description: t("relatedSalaryDesc"),
+    },
+    {
+      href: "/indicators",
+      title: t("relatedIndicatorsTitle"),
+      description: t("relatedIndicatorsDesc"),
+    },
+    {
+      href: "/comparison",
+      title: t("relatedComparisonTitle"),
+      description: t("relatedComparisonDesc"),
+    },
+  ];
 
   return (
     <>
@@ -29,6 +56,8 @@ export function WelfareSystemDetail() {
           {td("dataYear", { year: TAX_DATA_YEAR })}
         </p>
       </header>
+
+      <QuickAnswer title={t("quickAnswerTitle")} answer={t("quickAnswer")} />
 
       <section className="mb-10 rounded border border-gray-800 bg-[#0f1218] p-6">
         <p className="font-mono text-sm leading-relaxed text-blanc">
@@ -239,6 +268,10 @@ export function WelfareSystemDetail() {
           </div>
         </div>
       </section>
+
+      <FaqSection title={t("faqTitle")} faqs={faqs} />
+
+      <RelatedReports title={td("relatedReports")} reports={relatedReports} />
 
       <footer className="border-t border-gray-800 pt-4">
         <p className="font-mono text-xs text-blanc">

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -43,6 +43,34 @@ export function buildFaqJsonLd(faqs: FaqItem[]) {
   };
 }
 
+export function buildWebPageJsonLd({
+  title,
+  description,
+  path,
+  locale,
+}: {
+  title: string;
+  description: string;
+  path: string;
+  locale: Locale;
+}) {
+  const url = buildUrl(path, locale);
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: title,
+    description,
+    url,
+    isPartOf: {
+      "@type": "WebSite",
+      name: "impots.tax",
+      url: siteConfig.url,
+    },
+    inLanguage: locale === "fr" ? "fr-FR" : "en-US",
+  };
+}
+
 interface SeoMetadataOptions {
   title: string;
   description: string;

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,7 +1,11 @@
 {
   "metadata": {
-    "title": "impots.tax — Fiscal Command Center",
-    "description": "Satirical dashboard of French taxes and levies. Real data, dramatic presentation."
+    "title": "French Tax Monitor: France Tax Rates 2026 | impots.tax",
+    "description": "Official-source data on France tax rates, income tax brackets, flat tax, VAT, welfare benefits, debt and public spending."
+  },
+  "homeSeo": {
+    "quickAnswerTitle": "QUICK ANSWER",
+    "quickAnswer": "France tax rates in 2026 include income tax brackets from 0% to 45%, a 31.4% PFU flat tax for covered financial income, VAT rates of 20%, 10%, 5.5% and 2.1%, and total tax pressure near the top of the OECD."
   },
   "header": {
     "title": "FRENCH TAX MONITOR",
@@ -391,6 +395,7 @@
     "breadcrumbHome": "Dashboard",
     "source": "Source",
     "sources": "Sources",
+    "relatedReports": "RELATED REPORTS",
     "lastUpdated": "Last updated: {date}",
     "dataYear": "Data {year}",
     "perYear": "/year",
@@ -594,12 +599,14 @@
     "sourceText": "SNCF Réseau, ART, economiematin.fr, Senate (PLF 2026)"
   },
   "detailIncomeTax": {
-    "metaTitle": "Income Tax — 2026 Brackets | impots.tax",
-    "metaDescription": "France's progressive income tax brackets 2026 (2025 income). 5 escalation stages, from 0% to 45%. Official data, satirical framing.",
-    "title": "INCOME TAX",
+    "metaTitle": "France Income Tax Brackets 2026: 0% to 45% | impots.tax",
+    "metaDescription": "France income tax brackets for 2026 on 2025 income: 0%, 11%, 30%, 41% and 45% by tax share. Official-source data, satirical framing.",
+    "title": "FRANCE INCOME TAX BRACKETS 2026",
     "subtitle": "FISCAL ESCALATION REPORT — 2026 Brackets (2025 income)",
     "intro": "The French income tax is a progressive tax with brackets. Each bracket is another escalation level in state extraction. The schedule is indexed to inflation (+0.9% in 2026), meaning the State politely adjusts the starting point before extracting exactly as much as before.",
-    "bracketsTitle": "TAX BRACKETS",
+    "quickAnswerTitle": "QUICK ANSWER",
+    "quickAnswer": "France has five income tax brackets in 2026 for 2025 income: 0% up to €11,600, 11% from €11,601 to €29,579, 30% from €29,580 to €84,577, 41% from €84,578 to €181,917, and 45% above €181,917 per tax share.",
+    "bracketsTitle": "FRANCE TAX BRACKETS 2026",
     "bracket": "Bracket {number}",
     "bracketRange0": "Up to €11,600",
     "bracketRange1": "€11,601 to €29,579",
@@ -630,7 +637,13 @@
     "faqQ3": "What is the CDHR in 2026?",
     "faqA3": "The Differential Contribution on High Incomes (CDHR) is a brand-new minimum 20% effective tax rate targeting the wealthiest households. If your optimization strategies bring you below 20%, France adds a top-up to make sure you pay your 'fair share.'",
     "faqQ4": "What is the average income tax rate in France?",
-    "faqA4": "It depends entirely on income. At the median net salary of ~€2,190/month, the effective rate is around 13% via withholding. But the marginal rate can reach 45% — and with the new CDHR, even aggressive optimization won't bring the effective rate below 20%."
+    "faqA4": "It depends entirely on income. At the median net salary of ~€2,190/month, the effective rate is around 13% via withholding. But the marginal rate can reach 45% — and with the new CDHR, even aggressive optimization won't bring the effective rate below 20%.",
+    "relatedFlatTaxTitle": "France Flat Tax 2026",
+    "relatedFlatTaxDesc": "PFU rate, dividends, capital gains, crypto and the 31.4% update.",
+    "relatedSalaryTitle": "Salary Contributions",
+    "relatedSalaryDesc": "The employer cost, gross salary, net salary and social contribution breakdown.",
+    "relatedComparisonTitle": "International Comparison",
+    "relatedComparisonDesc": "France against OECD peers on total tax pressure."
   },
   "detailCorporateTax": {
     "metaTitle": "Corporate Tax — IS 2025-2026 | impots.tax",
@@ -659,11 +672,13 @@
     "sourceText": "economie.gouv.fr, entreprendre.service-public.fr, Finance Law 2026"
   },
   "detailFlatTax": {
-    "metaTitle": "Flat Tax / PFU — Flat-Rate Withholding | impots.tax",
-    "metaDescription": "Flat Tax/PFU 31.4% as of April 24, 2026 for covered financial income: 12.8% income tax + 18.6% social levies.",
-    "title": "FLAT TAX / PFU",
+    "metaTitle": "France Flat Tax 2026: PFU Rate 31.4% | impots.tax",
+    "metaDescription": "France flat tax and PFU rate in 2026: 31.4% for covered financial income, with 12.8% income tax and 18.6% social levies.",
+    "title": "FRANCE FLAT TAX / PFU 2026",
     "subtitle": "FLAT-RATE WITHHOLDING TAX REPORT",
     "intro": "The Prélèvement Forfaitaire Unique (PFU), known as the 'Flat Tax', was created in 2018 to simplify capital taxation. One rate, one operation. It was beautiful. It was simple. Which is why the State decided to complicate it in 2026 by increasing the CSG on investment income.",
+    "quickAnswerTitle": "QUICK ANSWER",
+    "quickAnswer": "France's ordinary PFU flat tax rate is 31.4% in 2026 for covered financial income: 12.8% income tax plus 18.6% social levies. The previous 30% total can still apply to some products and 2025 withholdings.",
     "rates2025Title": "PREVIOUS RATE / 2025 PRODUCTS WITHHELD",
     "rates2026Title": "RATE UPDATED APRIL 24, 2026",
     "componentIR": "Flat income tax",
@@ -689,14 +704,22 @@
     "faqQ3": "Does the flat tax apply to cryptocurrency?",
     "faqA3": "Yes. Private crypto-asset gains are taxed at the 31.4% PFU as of April 24, 2026: 12.8% income tax + 18.6% social levies. The progressive-scale option is made through box 3CN and is independent from the 2OP option for investment income.",
     "faqQ4": "Why is the flat tax increasing in 2026?",
-    "faqA4": "The CSG (social contribution) on financial income rises from 9.2% to 10.6%, pushing total social levies from 17.2% to 18.6%. The income tax portion stays at 12.8%. So the 'Flat Tax' goes from 30% to 31.4% — because 30% apparently wasn't enough."
+    "faqA4": "The CSG (social contribution) on financial income rises from 9.2% to 10.6%, pushing total social levies from 17.2% to 18.6%. The income tax portion stays at 12.8%. So the 'Flat Tax' goes from 30% to 31.4% — because 30% apparently wasn't enough.",
+    "relatedCapitalGainsTitle": "Capital Gains Outside PEA",
+    "relatedCapitalGainsDesc": "CTO vs PEA, S&P 500 investing and the cost of the French tax wrapper.",
+    "relatedIncomeTaxTitle": "Income Tax Brackets",
+    "relatedIncomeTaxDesc": "The 2026 progressive scale for 2025 income.",
+    "relatedVatTitle": "VAT Rates",
+    "relatedVatDesc": "France's 20%, 10%, 5.5% and 2.1% VAT rates."
   },
   "detailVat": {
-    "metaTitle": "VAT — Value Added Tax | impots.tax",
-    "metaDescription": "France's 4 VAT rates: 20%, 10%, 5.5%, 2.1%. Invented in France in 1954. The most discreet and efficient tax ever created.",
-    "title": "VAT",
+    "metaTitle": "France VAT Rates 2026: 20%, 10%, 5.5%, 2.1% | impots.tax",
+    "metaDescription": "France VAT rates in 2026: 20%, 10%, 5.5% and 2.1%. What each rate covers, how VAT works and why it is so efficient.",
+    "title": "FRANCE VAT RATES 2026",
     "subtitle": "REPORT ON THE MOST EFFICIENT FISCAL WEAPON EVER INVENTED",
     "intro": "The Value Added Tax is France's most exported fiscal invention. Created in 1954 by Maurice Lauré, it is now used by over 170 countries. Its genius: it's invisible. You pay it with every purchase without ever seeing it. The perfect tax according to the State — the one you don't notice.",
+    "quickAnswerTitle": "QUICK ANSWER",
+    "quickAnswer": "France applies four main VAT rates in 2026: 20% standard, 10% intermediate, 5.5% reduced and 2.1% special. Most goods and services fall under the standard 20% rate.",
     "ratesTitle": "THE 4 VAT RATES",
     "rateNormal": "Standard rate — 20%",
     "rateNormalDesc": "The majority of goods and services. Electronics, clothing, professional services, alcohol… everything that doesn't qualify for an exception.",
@@ -719,7 +742,13 @@
     "faqQ3": "Why is VAT considered the perfect tax?",
     "faqA3": "It's invisible (built into prices), collected at every production stage, nearly impossible to evade, and the consumer pays 100% without ever seeing a bill from the government. The State gets paid before you even reach the checkout counter.",
     "faqQ4": "Which products have the reduced 5.5% rate?",
-    "faqA4": "The 5.5% reduced rate applies notably to basic food (excluding alcohol, confectionery, and caviar), books, feminine sanitary protection products, disability equipment, heat produced from renewable energy, and live performances. Since August 1, 2025, gas and electricity subscriptions are taxed at the standard 20% rate."
+    "faqA4": "The 5.5% reduced rate applies notably to basic food (excluding alcohol, confectionery, and caviar), books, feminine sanitary protection products, disability equipment, heat produced from renewable energy, and live performances. Since August 1, 2025, gas and electricity subscriptions are taxed at the standard 20% rate.",
+    "relatedFuelTaxTitle": "Fuel Taxes",
+    "relatedFuelTaxDesc": "The SP95-E10 breakdown, excise duty and VAT applied on top.",
+    "relatedBehavioralTaxTitle": "Behavioral Taxes",
+    "relatedBehavioralTaxDesc": "Tobacco, alcohol and sugar taxes with the actual tax share.",
+    "relatedComparisonTitle": "International Comparison",
+    "relatedComparisonDesc": "How France's total tax pressure compares with OECD countries."
   },
   "detailFuelTax": {
     "metaTitle": "Fuel Taxes — Excise Duty, TICPE, VAT | impots.tax",
@@ -846,11 +875,13 @@
     "faqA4": "CSG (9.2%): created in 1991 as a 'temporary' 1.1% levy. Still here 35 years later, now 8× higher. CRDS (0.5%): created in 1996 to repay social debt. The debt grew, the tax stayed. In France, nothing is more permanent than a temporary tax."
   },
   "detailWelfareSystem": {
-    "metaTitle": "French Welfare System — RSA, AAH, ARE, AME | impots.tax",
-    "metaDescription": "RSA €646/month, AAH €1,033/month, ARE ~57% of salary, AME €1.386B. Conditions, amounts, beneficiaries. Official data.",
-    "title": "WELFARE SYSTEM",
+    "metaTitle": "French Welfare Benefits: RSA, AAH, ARE, AME | impots.tax",
+    "metaDescription": "French welfare benefits explained: RSA €646/month, AAH €1,033/month, ARE unemployment benefits and AME healthcare budget.",
+    "title": "FRENCH WELFARE BENEFITS 2025",
     "subtitle": "NATIONAL SAFETY NET REPORT — 2025",
     "intro": "The French welfare system is one of the most generous in the world. It is also one of the most expensive. Here is the detail of four major programs: RSA, AAH, ARE, and AME. Every euro collected through social contributions funds — among other things — these benefits.",
+    "quickAnswerTitle": "QUICK ANSWER",
+    "quickAnswer": "Major French welfare benefits include RSA at €646.52/month for a single person, AAH up to €1,033.32/month, ARE unemployment benefits at about 57% of reference salary and AME healthcare support with a €1.386B budget.",
     "rsaTitle": "RSA — MINIMUM INCOME (ACTIVE SOLIDARITY)",
     "rsaDesc": "The RSA is the guaranteed minimum income for people with no or very low income. Created in 2009 to replace the RMI, it is the last safety net of the French social system.",
     "rsaAmountsTitle": "MONTHLY AMOUNTS (April 2025)",
@@ -906,7 +937,22 @@
     "ameHospital": "Hospital: 60.8%",
     "ameCityCare": "Outpatient care: 26.5%",
     "amePharmacy": "Pharmacy: 12.7%",
-    "sourceText": "aide-sociale.fr, Service-Public.fr, monparcourshandicap.gouv.fr, handicap.fr, France Travail, Senate (Delahaye report), Boursorama, LDH, OID"
+    "sourceText": "aide-sociale.fr, Service-Public.fr, monparcourshandicap.gouv.fr, handicap.fr, France Travail, Senate (Delahaye report), Boursorama, LDH, OID",
+    "faqTitle": "FREQUENTLY ASKED QUESTIONS — FRENCH WELFARE",
+    "faqQ1": "How much is RSA in France?",
+    "faqA1": "The RSA is €646.52 per month for a single person from April 2025. The amount rises with household composition: €969.78 for a couple without children and €1,357.69 for a couple with two children.",
+    "faqQ2": "How much is AAH in France?",
+    "faqA2": "The AAH disability allowance can reach €1,033.32 per month at the full rate, with no income. It applies to people with a disability rate of at least 80%, or 50% to 79% with a substantial employment restriction.",
+    "faqQ3": "How are French unemployment benefits calculated?",
+    "faqA3": "ARE unemployment benefits are roughly 57% of the daily reference wage, or 40.4% plus €12.95 per day when that is more favorable. Eligibility generally requires at least six months of work.",
+    "faqQ4": "What is AME in France?",
+    "faqA4": "AME is healthcare support for undocumented immigrants who have lived in France for more than three months and meet income conditions. The 2024 actual spending figure used here is €1.386B.",
+    "relatedSalaryTitle": "Salary Contributions",
+    "relatedSalaryDesc": "The payroll charges that fund much of the French welfare system.",
+    "relatedIndicatorsTitle": "Macro Indicators",
+    "relatedIndicatorsDesc": "Debt, deficit and public spending behind the fiscal dashboard.",
+    "relatedComparisonTitle": "International Comparison",
+    "relatedComparisonDesc": "France's tax pressure against OECD peers."
   },
   "detailComparison": {
     "metaTitle": "International Comparison — Tax-to-GDP OECD Ranking | impots.tax",
@@ -941,11 +987,13 @@
     "sourceText": "OECD Revenue Statistics 2025"
   },
   "detailIndicators": {
-    "metaTitle": "Macro Indicators — Debt, Deficit, Public Spending | impots.tax",
-    "metaDescription": "Public debt €3,228B (112% of GDP), spending 56.5% of GDP, deficit -5.4%. The numbers that sum up the situation.",
-    "title": "MACRO INDICATORS",
+    "metaTitle": "France Debt, Deficit & Public Spending 2025 | impots.tax",
+    "metaDescription": "France macro indicators: public debt €3,228B, debt at 112% of GDP, public spending 56.5% of GDP and deficit -5.4%.",
+    "title": "FRANCE DEBT & DEFICIT 2025",
     "subtitle": "GENERAL SITUATION REPORT — France, 2024-2025",
     "intro": "Here are the numbers that sum up France's financial situation. A debt exceeding €3,200 billion, public spending among the highest in the world, and a deficit that won't close. These indicators are the result of decades of fiscal policy — the very policy this dashboard documents.",
+    "quickAnswerTitle": "QUICK ANSWER",
+    "quickAnswer": "France's public debt is about €3,228B, around 112% of GDP. Public spending is about 56.5% of GDP and the deficit is around -5.4%, despite one of the highest tax burdens in the OECD.",
     "debtTitle": "PUBLIC DEBT",
     "debtAmount": "~€3,228B (end of 2024 estimate)",
     "debtRatio": "Debt-to-GDP ratio: ~112%",
@@ -964,7 +1012,22 @@
     "plafondSS": "Monthly SS ceiling 2026: €4,005",
     "summaryTitle": "SUMMARY",
     "summaryDesc": "France is the country that collects the most taxes in the world (46.1% of GDP), spends the most (~56.5% of GDP), and despite all that, keeps accumulating more debt (112% of GDP). The equation only works thanks to borrowing capacity — as long as markets keep lending.",
-    "sourceText": "INSEE, Eurostat — 2024-2025 estimates"
+    "sourceText": "INSEE, Eurostat — 2024-2025 estimates",
+    "faqTitle": "FREQUENTLY ASKED QUESTIONS — FRANCE MACRO INDICATORS",
+    "faqQ1": "What is France's public debt?",
+    "faqA1": "France's public debt is about €3,228B, estimated around 112% of GDP. That means the State owes roughly €1.12 for every euro of annual output.",
+    "faqQ2": "What is France's public spending as a share of GDP?",
+    "faqA2": "French public spending is estimated at about 56.5% of GDP, one of the highest levels in the OECD.",
+    "faqQ3": "What is France's budget deficit?",
+    "faqA3": "The deficit figure used here is around -5.4% of GDP. Even with record tax pressure, spending still exceeds revenue.",
+    "faqQ4": "Why does France still borrow with such high taxes?",
+    "faqA4": "Because public spending remains higher than public revenue. High taxes reduce the gap, but they do not close it when spending stays above receipts.",
+    "relatedComparisonTitle": "International Comparison",
+    "relatedComparisonDesc": "France against OECD countries on total tax pressure.",
+    "relatedWelfareTitle": "French Welfare Benefits",
+    "relatedWelfareDesc": "RSA, AAH, ARE and AME as major spending-side programs.",
+    "relatedSalaryTitle": "Salary Contributions",
+    "relatedSalaryDesc": "The labor-cost extraction that funds social insurance."
   },
   "report": {
     "button": "Report a problem",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -3,6 +3,10 @@
     "title": "impots.tax — Centre de Commandement Fiscal",
     "description": "Tableau de bord satirique des impôts et taxes en France. Données réelles, présentation dramatique."
   },
+  "homeSeo": {
+    "quickAnswerTitle": "RÉPONSE COURTE",
+    "quickAnswer": "Les taux d'imposition français en 2026 incluent un barème d'impôt sur le revenu de 0% à 45%, une Flat Tax/PFU à 31.4% pour les revenus financiers concernés, des taux de TVA à 20%, 10%, 5.5% et 2.1%, et une pression fiscale parmi les plus élevées de l'OCDE."
+  },
   "header": {
     "title": "FRENCH TAX MONITOR",
     "monitoring": "SURVEILLANCE ACTIVE",
@@ -391,6 +395,7 @@
     "breadcrumbHome": "Dashboard",
     "source": "Source",
     "sources": "Sources",
+    "relatedReports": "RAPPORTS LIÉS",
     "lastUpdated": "Dernière mise à jour : {date}",
     "dataYear": "Données {year}",
     "perYear": "/an",
@@ -599,6 +604,8 @@
     "title": "IMPÔT SUR LE REVENU",
     "subtitle": "RAPPORT D'ESCALADE FISCALE — Barème 2026 (revenus 2025)",
     "intro": "L'impôt sur le revenu français est un impôt progressif par tranches. Chaque tranche est un niveau d'escalade supplémentaire dans l'extraction étatique. Le barème est indexé sur l'inflation (+0.9% en 2026), ce qui signifie que l'État ajuste poliment le point de départ avant de prélever exactement autant qu'avant.",
+    "quickAnswerTitle": "RÉPONSE COURTE",
+    "quickAnswer": "Le barème français de l'impôt sur le revenu 2026 sur les revenus 2025 compte cinq tranches par part fiscale : 0% jusqu'à 11 600 €, 11% de 11 601 € à 29 579 €, 30% de 29 580 € à 84 577 €, 41% de 84 578 € à 181 917 €, puis 45% au-delà.",
     "bracketsTitle": "TRANCHES D'IMPOSITION",
     "bracket": "Tranche {number}",
     "bracketRange0": "Jusqu'à 11 600 €",
@@ -630,7 +637,13 @@
     "faqQ3": "Qu'est-ce que la CDHR en 2026 ?",
     "faqA3": "La Contribution Différentielle sur les Hauts Revenus (CDHR) est une nouveauté 2026 qui garantit un taux d'imposition effectif minimum de 20% pour les foyers les plus aisés. Elle vise les contribuables qui, grâce à l'optimisation fiscale (niches, revenus du capital), parviennent à afficher un taux effectif inférieur à 20% malgré des revenus élevés. L'État a décidé que l'optimisation fiscale avait des limites — les siennes.",
     "faqQ4": "Quel est le taux d'imposition moyen en France ?",
-    "faqA4": "Le taux marginal d'imposition (TMI) le plus courant est 30%, mais le taux effectif est bien plus bas. Pour un salaire médian net de ~2 190 €/mois, le taux effectif d'IR se situe autour de 7-10%. Seuls les foyers au-delà de ~84 577 € par part atteignent les tranches à 41% et 45%. Au total, l'IR ne représente qu'une fraction du prélèvement total — les cotisations sociales (~52%) sont le vrai poste de ponction."
+    "faqA4": "Le taux marginal d'imposition (TMI) le plus courant est 30%, mais le taux effectif est bien plus bas. Pour un salaire médian net de ~2 190 €/mois, le taux effectif d'IR se situe autour de 7-10%. Seuls les foyers au-delà de ~84 577 € par part atteignent les tranches à 41% et 45%. Au total, l'IR ne représente qu'une fraction du prélèvement total — les cotisations sociales (~52%) sont le vrai poste de ponction.",
+    "relatedFlatTaxTitle": "Flat Tax 2026",
+    "relatedFlatTaxDesc": "PFU, dividendes, plus-values, crypto et passage à 31.4%.",
+    "relatedSalaryTitle": "Salaires & cotisations",
+    "relatedSalaryDesc": "Le coût employeur, le brut, le net et les prélèvements sociaux.",
+    "relatedComparisonTitle": "Comparaison internationale",
+    "relatedComparisonDesc": "La pression fiscale française face aux pays de l'OCDE."
   },
   "detailCorporateTax": {
     "metaTitle": "Impôt sur les sociétés — IS 2025-2026 | impots.tax",
@@ -664,6 +677,8 @@
     "title": "FLAT TAX / PFU",
     "subtitle": "RAPPORT SUR LE PRÉLÈVEMENT FORFAITAIRE UNIQUE",
     "intro": "Le Prélèvement Forfaitaire Unique (PFU), dit « Flat Tax », a été créé en 2018 pour simplifier la taxation du capital. Un taux unique, une seule opération. C'était beau. C'était simple. C'est pourquoi l'État a décidé de le compliquer dès 2026 en augmentant la CSG sur les revenus financiers.",
+    "quickAnswerTitle": "RÉPONSE COURTE",
+    "quickAnswer": "Le PFU ordinaire, ou Flat Tax, est de 31.4% en France en 2026 pour les revenus financiers concernés : 12.8% d'impôt sur le revenu et 18.6% de prélèvements sociaux. L'ancien total de 30% reste pertinent pour certains produits et prélèvements 2025.",
     "rates2025Title": "ANCIEN TAUX / PRODUITS 2025 PRÉLEVÉS",
     "rates2026Title": "TAUX À JOUR AU 24 AVRIL 2026",
     "componentIR": "IR forfaitaire",
@@ -689,7 +704,13 @@
     "faqQ3": "La flat tax s'applique-t-elle aux crypto-monnaies ?",
     "faqA3": "Oui. Les plus-values sur actifs numériques réalisées dans le cadre du patrimoine privé sont soumises au PFU de 31.4% au 24 avril 2026 : 12.8% d'impôt + 18.6% de prélèvements sociaux. L'option pour le barème progressif se fait via la case 3CN et elle est indépendante de l'option 2OP des revenus de capitaux mobiliers.",
     "faqQ4": "Pourquoi la flat tax augmente en 2026 ?",
-    "faqA4": "La loi de financement de la Sécurité sociale 2026 (LFSS, loi n°2025-1403) relève la CSG sur les revenus du capital de 9.2% à 10.6%, soit +1.4 point. Cela porte les prélèvements sociaux de 17.2% à 18.6%, et donc le PFU total de 30% à 31.4%. La part IR (12.8%) reste inchangée. La « Flat Tax » — censée être simple et stable — aura donc augmenté de 4.7% en moins d'une décennie d'existence."
+    "faqA4": "La loi de financement de la Sécurité sociale 2026 (LFSS, loi n°2025-1403) relève la CSG sur les revenus du capital de 9.2% à 10.6%, soit +1.4 point. Cela porte les prélèvements sociaux de 17.2% à 18.6%, et donc le PFU total de 30% à 31.4%. La part IR (12.8%) reste inchangée. La « Flat Tax » — censée être simple et stable — aura donc augmenté de 4.7% en moins d'une décennie d'existence.",
+    "relatedCapitalGainsTitle": "Plus-values hors PEA",
+    "relatedCapitalGainsDesc": "CTO vs PEA, S&P 500 et coût fiscal de l'enveloppe française.",
+    "relatedIncomeTaxTitle": "Barème IR",
+    "relatedIncomeTaxDesc": "Le barème progressif 2026 sur les revenus 2025.",
+    "relatedVatTitle": "Taux de TVA",
+    "relatedVatDesc": "Les taux français à 20%, 10%, 5.5% et 2.1%."
   },
   "detailVat": {
     "metaTitle": "TVA — Taxe sur la Valeur Ajoutée | impots.tax",
@@ -697,6 +718,8 @@
     "title": "TVA",
     "subtitle": "RAPPORT SUR L'ARME FISCALE LA PLUS EFFICACE JAMAIS INVENTÉE",
     "intro": "La Taxe sur la Valeur Ajoutée est l'invention fiscale française la plus exportée au monde. Créée en 1954 par Maurice Lauré, elle est aujourd'hui utilisée par plus de 170 pays. Son génie : elle est invisible. Vous la payez à chaque achat sans jamais la voir. L'impôt parfait selon l'État — celui que vous ne remarquez pas.",
+    "quickAnswerTitle": "RÉPONSE COURTE",
+    "quickAnswer": "La France applique quatre principaux taux de TVA en 2026 : 20% pour le taux normal, 10% pour le taux intermédiaire, 5.5% pour le taux réduit et 2.1% pour le taux particulier. La plupart des biens et services relèvent du taux normal à 20%.",
     "ratesTitle": "LES 4 TAUX DE TVA",
     "rateNormal": "Taux normal — 20%",
     "rateNormalDesc": "La majorité des biens et services. Électronique, vêtements, services professionnels, alcool… tout ce qui ne bénéficie pas d'une exception.",
@@ -719,7 +742,13 @@
     "faqQ3": "Pourquoi la TVA est-elle considérée comme l'impôt parfait ?",
     "faqA3": "Du point de vue de l'État, la TVA est un chef-d'œuvre : elle est invisible (intégrée au prix, le consommateur ne la « voit » pas), collectée à chaque étape de la chaîne (fabrication, distribution, vente), quasi-impossible à frauder (chaque maillon vérifie l'autre via le mécanisme de TVA déductible/collectée), et supportée intégralement par le consommateur final. C'est un impôt sur la consommation, pas sur la production — ce qui le rend indolore pour les entreprises et invisible pour les citoyens.",
     "faqQ4": "Quels produits bénéficient du taux réduit de 5.5% ?",
-    "faqA4": "Le taux réduit de 5.5% s'applique notamment aux produits alimentaires (sauf alcool, confiseries et caviar), aux livres (papier et numériques), aux produits de protection hygiénique féminine, aux équipements pour personnes handicapées, à la fourniture de chaleur produite à partir d'énergies renouvelables, et aux spectacles vivants. Attention : depuis le 1er août 2025, les abonnements de gaz et d'électricité sont passés au taux normal de 20%."
+    "faqA4": "Le taux réduit de 5.5% s'applique notamment aux produits alimentaires (sauf alcool, confiseries et caviar), aux livres (papier et numériques), aux produits de protection hygiénique féminine, aux équipements pour personnes handicapées, à la fourniture de chaleur produite à partir d'énergies renouvelables, et aux spectacles vivants. Attention : depuis le 1er août 2025, les abonnements de gaz et d'électricité sont passés au taux normal de 20%.",
+    "relatedFuelTaxTitle": "Taxes carburant",
+    "relatedFuelTaxDesc": "SP95-E10, accise et TVA appliquée sur l'accise.",
+    "relatedBehavioralTaxTitle": "Taxes comportementales",
+    "relatedBehavioralTaxDesc": "Tabac, alcool, sucre et part réelle des taxes.",
+    "relatedComparisonTitle": "Comparaison internationale",
+    "relatedComparisonDesc": "La pression fiscale française face aux pays de l'OCDE."
   },
   "detailFuelTax": {
     "metaTitle": "Taxes sur le carburant — Accise, TICPE, TVA | impots.tax",
@@ -851,6 +880,8 @@
     "title": "SYSTÈME SOCIAL",
     "subtitle": "RAPPORT SUR LE FILET DE SÉCURITÉ NATIONALE — 2025",
     "intro": "Le système social français est l'un des plus généreux au monde. Il est aussi l'un des plus coûteux. Voici le détail de quatre dispositifs majeurs : RSA, AAH, ARE et AME. Chaque euro prélevé dans les cotisations sociales finance — entre autres — ces prestations.",
+    "quickAnswerTitle": "RÉPONSE COURTE",
+    "quickAnswer": "Les grandes prestations sociales françaises incluent le RSA à 646.52 €/mois pour une personne seule, l'AAH jusqu'à 1 033.32 €/mois, l'ARE autour de 57% du salaire de référence et l'AME avec 1.386 Md € de dépenses réelles 2024.",
     "rsaTitle": "RSA — REVENU DE SOLIDARITÉ ACTIVE",
     "rsaDesc": "Le RSA est le revenu minimum garanti pour les personnes sans ressources ou à très faibles revenus. Créé en 2009 pour remplacer le RMI, il constitue le dernier filet de sécurité du système social français.",
     "rsaAmountsTitle": "MONTANTS MENSUELS (avril 2025)",
@@ -906,7 +937,22 @@
     "ameHospital": "Hospitalier : 60.8%",
     "ameCityCare": "Soins de ville : 26.5%",
     "amePharmacy": "Pharmacie : 12.7%",
-    "sourceText": "aide-sociale.fr, Service-Public.fr, monparcourshandicap.gouv.fr, handicap.fr, France Travail, Sénat (rapport Delahaye), Boursorama, LDH, OID"
+    "sourceText": "aide-sociale.fr, Service-Public.fr, monparcourshandicap.gouv.fr, handicap.fr, France Travail, Sénat (rapport Delahaye), Boursorama, LDH, OID",
+    "faqTitle": "QUESTIONS FRÉQUENTES — SYSTÈME SOCIAL",
+    "faqQ1": "Quel est le montant du RSA en France ?",
+    "faqA1": "Le RSA est de 646.52 € par mois pour une personne seule depuis avril 2025. Le montant augmente selon la composition du foyer : 969.78 € pour un couple sans enfant et 1 357.69 € pour un couple avec deux enfants.",
+    "faqQ2": "Quel est le montant de l'AAH en France ?",
+    "faqA2": "L'AAH peut atteindre 1 033.32 € par mois à taux plein, sans revenus. Elle concerne les personnes avec un taux d'incapacité d'au moins 80%, ou entre 50% et 79% avec restriction substantielle d'accès à l'emploi.",
+    "faqQ3": "Comment est calculée l'allocation chômage ARE ?",
+    "faqA3": "L'ARE représente environ 57% du salaire journalier de référence, ou 40.4% plus 12.95 € par jour si ce calcul est plus favorable. L'éligibilité demande généralement au moins six mois de travail.",
+    "faqQ4": "Qu'est-ce que l'AME en France ?",
+    "faqA4": "L'AME est une aide médicale destinée aux étrangers en situation irrégulière résidant en France depuis plus de trois mois et remplissant des conditions de ressources. Le chiffre de dépenses réelles 2024 retenu ici est 1.386 Md €.",
+    "relatedSalaryTitle": "Salaires & cotisations",
+    "relatedSalaryDesc": "Les prélèvements sur le travail qui financent une partie du système social.",
+    "relatedIndicatorsTitle": "Indicateurs macro",
+    "relatedIndicatorsDesc": "Dette, déficit et dépenses publiques derrière le tableau de bord.",
+    "relatedComparisonTitle": "Comparaison internationale",
+    "relatedComparisonDesc": "La pression fiscale française face aux pays de l'OCDE."
   },
   "detailComparison": {
     "metaTitle": "Comparaison internationale — Ratio taxes/PIB OCDE | impots.tax",
@@ -946,6 +992,8 @@
     "title": "INDICATEURS MACRO",
     "subtitle": "RAPPORT DE SITUATION GÉNÉRALE — France, 2024-2025",
     "intro": "Voici les chiffres qui résument la situation financière de la France. Une dette qui dépasse 3 200 milliards d'euros, des dépenses publiques parmi les plus élevées au monde, et un déficit qui ne se résorbe pas. Ces indicateurs sont le résultat de décennies de politique fiscale — celle-là même que ce tableau de bord documente.",
+    "quickAnswerTitle": "RÉPONSE COURTE",
+    "quickAnswer": "La dette publique française est d'environ 3 228 Mds €, soit environ 112% du PIB. Les dépenses publiques représentent environ 56.5% du PIB et le déficit environ -5.4%, malgré une pression fiscale parmi les plus élevées de l'OCDE.",
     "debtTitle": "DETTE PUBLIQUE",
     "debtAmount": "~3 228 Mds € (estimation fin 2024)",
     "debtRatio": "Ratio dette/PIB : ~112%",
@@ -964,7 +1012,22 @@
     "plafondSS": "Plafond SS mensuel 2026 : 4 005 €",
     "summaryTitle": "SYNTHÈSE",
     "summaryDesc": "La France est le pays qui prélève le plus de taxes au monde (46.1% du PIB), qui dépense le plus (~56.5% du PIB), et qui malgré cela accumule toujours plus de dette (112% du PIB). L'équation ne tient que grâce à la capacité d'emprunt — tant que les marchés continuent de prêter.",
-    "sourceText": "INSEE, Eurostat — estimations 2024-2025"
+    "sourceText": "INSEE, Eurostat — estimations 2024-2025",
+    "faqTitle": "QUESTIONS FRÉQUENTES — INDICATEURS MACRO",
+    "faqQ1": "Quel est le montant de la dette publique française ?",
+    "faqA1": "La dette publique française est d'environ 3 228 Mds €, soit environ 112% du PIB. Autrement dit, l'État doit environ 1.12 € pour chaque euro de richesse annuelle produite.",
+    "faqQ2": "Quel est le niveau des dépenses publiques en France ?",
+    "faqA2": "Les dépenses publiques françaises sont estimées à environ 56.5% du PIB, parmi les niveaux les plus élevés de l'OCDE.",
+    "faqQ3": "Quel est le déficit public de la France ?",
+    "faqA3": "Le déficit retenu ici est d'environ -5.4% du PIB. Même avec une pression fiscale record, les dépenses restent supérieures aux recettes.",
+    "faqQ4": "Pourquoi la France emprunte-t-elle encore avec autant d'impôts ?",
+    "faqA4": "Parce que les dépenses publiques restent supérieures aux recettes publiques. Les impôts élevés réduisent l'écart, mais ne le ferment pas lorsque les dépenses dépassent les prélèvements.",
+    "relatedComparisonTitle": "Comparaison internationale",
+    "relatedComparisonDesc": "La France face aux pays de l'OCDE sur la pression fiscale totale.",
+    "relatedWelfareTitle": "Système social français",
+    "relatedWelfareDesc": "RSA, AAH, ARE et AME parmi les grands postes sociaux.",
+    "relatedSalaryTitle": "Salaires & cotisations",
+    "relatedSalaryDesc": "Le coût du travail et les cotisations qui financent l'assurance sociale."
   },
   "report": {
     "button": "Signaler un problème",


### PR DESCRIPTION
## Summary
- Add English quick-answer blocks and related report links on priority SEO pages.
- Add WebPage JSON-LD and FAQPage JSON-LD where relevant.
- Switch localized content pages to SSG through next-intl setRequestLocale.
- Update English metadata for the Search Console priority pages and refresh sitemap lastmod.

## Validation
- npm run type-check
- npm run build
- npm run lint
- Checked generated HTML for title, description, canonical, hreflang, JSON-LD and quick-answer content on priority English pages.